### PR TITLE
Add KoboldCpp provider with native API support

### DIFF
--- a/server/src/routes/onboarding.js
+++ b/server/src/routes/onboarding.js
@@ -93,20 +93,26 @@ router.post('/persona', asyncHandler(async (req, res) => {
 
 // Create preset during onboarding
 router.post('/preset', asyncHandler(async (req, res) => {
-  const { provider, apiKey } = req.body;
+  const { provider, apiKey, baseURL, password } = req.body;
 
   if (!provider) {
     throw new AppError('Provider is required', 400);
   }
 
-  const validProviders = ['deepseek', 'openai', 'anthropic', 'openrouter', 'aihorde'];
+  const validProviders = ['deepseek', 'openai', 'anthropic', 'openrouter', 'aihorde', 'koboldcpp'];
   if (!validProviders.includes(provider)) {
     throw new AppError(`Invalid provider. Must be one of: ${validProviders.join(', ')}`, 400);
   }
 
-  // AI Horde doesn't require an API key
-  if (provider !== 'aihorde' && (!apiKey || !apiKey.trim())) {
+  // AI Horde and KoboldCpp don't require an API key
+  const providersWithoutApiKey = ['aihorde', 'koboldcpp'];
+  if (!providersWithoutApiKey.includes(provider) && (!apiKey || !apiKey.trim())) {
     throw new AppError('API key is required for this provider', 400);
+  }
+
+  // KoboldCpp requires a base URL
+  if (provider === 'koboldcpp' && (!baseURL || !baseURL.trim())) {
+    throw new AppError('Base URL is required for KoboldCpp', 400);
   }
 
   // Basic API key validation
@@ -131,7 +137,7 @@ router.post('/preset', asyncHandler(async (req, res) => {
   const presetId = uuidv4();
 
   // Get provider-specific configuration
-  const presetConfig = getProviderPresetConfig(provider, apiKey);
+  const presetConfig = getProviderPresetConfig(provider, apiKey, { baseURL, password });
 
   await storage.savePreset(presetId, {
     ...presetConfig,
@@ -218,7 +224,7 @@ router.post('/skip', asyncHandler(async (req, res) => {
 /**
  * Get provider-specific preset configuration
  */
-function getProviderPresetConfig(provider, apiKey) {
+function getProviderPresetConfig(provider, apiKey, extraConfig = {}) {
   const baseConfig = {
     generationSettings: {
       maxTokens: 4000,
@@ -324,6 +330,26 @@ function getProviderPresetConfig(provider, apiKey) {
           rep_pen: 1.1,
           rep_pen_range: 320,
           sampler_order: [6, 0, 1, 3, 4, 2, 5],
+        },
+        lorebookSettings: baseConfig.lorebookSettings,
+        promptTemplates: baseConfig.promptTemplates
+      };
+
+    case 'koboldcpp':
+      return {
+        name: 'KoboldCpp',
+        provider: 'koboldcpp',
+        apiConfig: {
+          baseURL: (extraConfig.baseURL || 'http://localhost:5001/api').trim(),
+          password: (extraConfig.password || '').trim(),
+          model: ''
+        },
+        generationSettings: {
+          maxTokens: 200,
+          maxContextTokens: 4096,
+          temperature: 0.7,
+          includeDialogueExamples: false,
+          stop_sequences: []
         },
         lorebookSettings: baseConfig.lorebookSettings,
         promptTemplates: baseConfig.promptTemplates

--- a/server/src/routes/presets.js
+++ b/server/src/routes/presets.js
@@ -12,6 +12,7 @@ import { OpenRouterProvider } from '../services/providers/openrouter-provider.js
 import { OpenAIProvider } from '../services/providers/openai-provider.js';
 import { AnthropicProvider } from '../services/providers/anthropic-provider.js';
 import { DeepSeekProvider } from '../services/providers/deepseek-provider.js';
+import { KoboldCppProvider } from '../services/providers/koboldcpp-provider.js';
 
 const router = express.Router();
 
@@ -415,6 +416,32 @@ router.get('/deepseek/models', asyncHandler(async (req, res) => {
     res.status(500).json({
       error: 'Failed to fetch models from DeepSeek',
       message: error.message
+    });
+  }
+}));
+
+// Inspect a KoboldCpp endpoint: returns loaded model + configured max context length.
+// No caching — local endpoint, can change anytime a user hot-swaps a model.
+router.get('/koboldcpp/info', asyncHandler(async (req, res) => {
+  const baseURL = req.query.baseURL;
+  const password = req.query.password || '';
+
+  if (!baseURL) {
+    return res.status(400).json({
+      error: 'baseURL query parameter is required'
+    });
+  }
+
+  try {
+    const provider = new KoboldCppProvider({ baseURL, password });
+    const info = await provider.getEndpointInfo();
+    res.json(info);
+  } catch (error) {
+    console.error('Failed to inspect KoboldCpp endpoint:', error);
+    res.status(502).json({
+      error: 'Could not reach KoboldCpp',
+      message: `Could not reach KoboldCpp at ${baseURL}. Is it running?`,
+      detail: error.message
     });
   }
 }));

--- a/server/src/services/default-presets.js
+++ b/server/src/services/default-presets.js
@@ -101,6 +101,50 @@ export const DEFAULT_PROMPT_TEMPLATES = {
 
 export function getDefaultPresets() {
   return {
+    koboldcpp: {
+      name: "KoboldCpp",
+      provider: "koboldcpp",
+      apiConfig: {
+        baseURL: "http://localhost:5001/api",
+        password: "",
+        model: ""
+      },
+      generationSettings: {
+        maxTokens: 200,
+        maxContextTokens: 4096,
+        temperature: 0.7,
+        includeDialogueExamples: false,
+        top_p: null,
+        top_k: null,
+        top_a: null,
+        typical: null,
+        tfs: null,
+        min_p: null,
+        rep_pen: null,
+        rep_pen_range: null,
+        rep_pen_slope: null,
+        sampler_order: null,
+        mirostat: null,
+        mirostat_tau: null,
+        mirostat_eta: null,
+        stop_sequences: []
+      },
+      lorebookSettings: {
+        scanDepth: 2000,
+        tokenBudget: 1800,
+        recursionDepth: 3,
+        enableRecursion: true
+      },
+      promptTemplates: {
+        systemPrompt: null,
+        continue: null,
+        character: null,
+        instruction: null,
+        rewriteThirdPerson: null,
+        ideate: null,
+        storyStarter: null
+      }
+    },
     aihorde: {
       name: "Default",
       provider: "aihorde",

--- a/server/src/services/provider-factory.js
+++ b/server/src/services/provider-factory.js
@@ -8,6 +8,7 @@ import { AIHordeProvider } from './providers/aihorde-provider.js';
 import { OpenRouterProvider } from './providers/openrouter-provider.js';
 import { OpenAIProvider } from './providers/openai-provider.js';
 import { AnthropicProvider } from './providers/anthropic-provider.js';
+import { KoboldCppProvider } from './providers/koboldcpp-provider.js';
 
 // Provider registry
 const PROVIDERS = {
@@ -16,6 +17,7 @@ const PROVIDERS = {
   openrouter: OpenRouterProvider,
   openai: OpenAIProvider,
   anthropic: AnthropicProvider,
+  koboldcpp: KoboldCppProvider,
 };
 
 /**

--- a/server/src/services/providers/__tests__/koboldcpp-provider.test.js
+++ b/server/src/services/providers/__tests__/koboldcpp-provider.test.js
@@ -1,0 +1,459 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { KoboldCppProvider } from '../koboldcpp-provider.js';
+
+function streamFrom(chunks) {
+  return new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    }
+  });
+}
+
+async function collectStream(asyncIter) {
+  const out = [];
+  for await (const v of asyncIter) out.push(v);
+  return out;
+}
+
+describe('KoboldCppProvider', () => {
+  let provider;
+  let mockFetch;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    provider = new KoboldCppProvider({ baseURL: 'http://localhost:5001' });
+  });
+
+  describe('Configuration', () => {
+    it('defaults baseURL to http://localhost:5001 (after /api normalization)', () => {
+      const p = new KoboldCppProvider({});
+      expect(p.baseURL).toBe('http://localhost:5001');
+    });
+
+    it('strips trailing slashes from baseURL', () => {
+      const p = new KoboldCppProvider({ baseURL: 'http://example.com:5001//' });
+      expect(p.baseURL).toBe('http://example.com:5001');
+    });
+
+    it('strips trailing /api so users can paste either form', () => {
+      const withApi = new KoboldCppProvider({ baseURL: 'http://192.168.1.157:5001/api' });
+      const withoutApi = new KoboldCppProvider({ baseURL: 'http://192.168.1.157:5001' });
+      expect(withApi.baseURL).toBe('http://192.168.1.157:5001');
+      expect(withoutApi.baseURL).toBe('http://192.168.1.157:5001');
+    });
+
+    it('strips trailing /api/ with trailing slash', () => {
+      const p = new KoboldCppProvider({ baseURL: 'http://localhost:5001/api/' });
+      expect(p.baseURL).toBe('http://localhost:5001');
+    });
+
+    it('stores password when provided', () => {
+      const p = new KoboldCppProvider({ password: 'secret' });
+      expect(p.password).toBe('secret');
+    });
+
+    it('defaults password to empty string', () => {
+      expect(provider.password).toBe('');
+    });
+  });
+
+  describe('Capabilities', () => {
+    it('reports streaming true, reasoning/vision false', () => {
+      const caps = provider.getCapabilities();
+      expect(caps.streaming).toBe(true);
+      expect(caps.reasoning).toBe(false);
+      expect(caps.visionAPI).toBe(false);
+    });
+  });
+
+  describe('Validation', () => {
+    it('passes when baseURL is set (no apiKey required)', () => {
+      expect(provider.validateConfig()).toEqual({ valid: true });
+    });
+
+    it('fails when baseURL is empty', () => {
+      const p = new KoboldCppProvider({ baseURL: '   ' });
+      const result = p.validateConfig();
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('Auth Headers', () => {
+    it('omits Authorization when no password', () => {
+      const headers = provider.authHeaders();
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['Authorization']).toBeUndefined();
+    });
+
+    it('includes Bearer Authorization when password set', () => {
+      const p = new KoboldCppProvider({ password: 'hunter2' });
+      expect(p.authHeaders()['Authorization']).toBe('Bearer hunter2');
+    });
+  });
+
+  describe('Request Body Building', () => {
+    it('puts system prompt in memory and user prompt in prompt', () => {
+      const body = provider.buildRequestBody('SYS', 'USR', {});
+      expect(body.prompt).toBe('USR');
+      expect(body.memory).toBe('SYS');
+    });
+
+    it('uses defaults for max_length, max_context_length, temperature', () => {
+      const body = provider.buildRequestBody('', '', {});
+      expect(body.max_length).toBe(200);
+      expect(body.max_context_length).toBe(4096);
+      expect(body.temperature).toBe(0.7);
+    });
+
+    it('overrides defaults from options', () => {
+      const body = provider.buildRequestBody('', '', {
+        maxTokens: 500,
+        maxContextTokens: 8192,
+        temperature: 1.2
+      });
+      expect(body.max_length).toBe(500);
+      expect(body.max_context_length).toBe(8192);
+      expect(body.temperature).toBe(1.2);
+    });
+
+    it('always sets use_default_badwordsids and trim_stop', () => {
+      const body = provider.buildRequestBody('', '', {});
+      expect(body.use_default_badwordsids).toBe(true);
+      expect(body.trim_stop).toBe(true);
+    });
+
+    it('passes through sampler params when set', () => {
+      const body = provider.buildRequestBody('', '', {
+        top_p: 0.9, top_k: 40, top_a: 0.1, typical: 0.95, tfs: 0.95, min_p: 0.05,
+        rep_pen: 1.15, rep_pen_range: 512, rep_pen_slope: 0.7,
+        sampler_order: [6, 0, 1, 3, 4, 2, 5],
+        mirostat: 2, mirostat_tau: 5.0, mirostat_eta: 0.1
+      });
+      expect(body.top_p).toBe(0.9);
+      expect(body.top_k).toBe(40);
+      expect(body.top_a).toBe(0.1);
+      expect(body.typical).toBe(0.95);
+      expect(body.tfs).toBe(0.95);
+      expect(body.min_p).toBe(0.05);
+      expect(body.rep_pen).toBe(1.15);
+      expect(body.rep_pen_range).toBe(512);
+      expect(body.rep_pen_slope).toBe(0.7);
+      expect(body.sampler_order).toEqual([6, 0, 1, 3, 4, 2, 5]);
+      expect(body.mirostat).toBe(2);
+      expect(body.mirostat_tau).toBe(5.0);
+      expect(body.mirostat_eta).toBe(0.1);
+    });
+
+    it('omits sampler params when null or undefined', () => {
+      const body = provider.buildRequestBody('', '', {
+        top_p: null,
+        top_k: undefined,
+        mirostat: null
+      });
+      expect(body.top_p).toBeUndefined();
+      expect(body.top_k).toBeUndefined();
+      expect(body.mirostat).toBeUndefined();
+    });
+
+    it('maps stop_sequences to stop_sequence', () => {
+      const body = provider.buildRequestBody('', '', { stop_sequences: ['END', '\n\n'] });
+      expect(body.stop_sequence).toEqual(['END', '\n\n']);
+    });
+
+    it('omits stop_sequence when empty', () => {
+      const body = provider.buildRequestBody('', '', { stop_sequences: [] });
+      expect(body.stop_sequence).toBeUndefined();
+    });
+
+    it('includes genkey when provided', () => {
+      const body = provider.buildRequestBody('', '', {}, 'KCPP_test123');
+      expect(body.genkey).toBe('KCPP_test123');
+    });
+
+    it('omits genkey when not provided', () => {
+      const body = provider.buildRequestBody('', '', {});
+      expect(body.genkey).toBeUndefined();
+    });
+  });
+
+  describe('Generate (non-streaming)', () => {
+    it('POSTs to /api/v1/generate with native body and returns text', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [{ text: 'Hello world' }] })
+      });
+
+      const result = await provider.generate('SYS', 'USR', { maxTokens: 100 });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:5001/api/v1/generate');
+      expect(opts.method).toBe('POST');
+      const body = JSON.parse(opts.body);
+      expect(body.prompt).toBe('USR');
+      expect(body.memory).toBe('SYS');
+      expect(body.max_length).toBe(100);
+      expect(body.genkey).toMatch(/^KCPP_/);
+      expect(result.content).toBe('Hello world');
+      expect(result.reasoning).toBe('');
+    });
+
+    it('includes Bearer header when password is set', async () => {
+      const p = new KoboldCppProvider({ baseURL: 'http://localhost:5001', password: 'secret' });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [{ text: 'ok' }] })
+      });
+      await p.generate('s', 'u');
+      expect(mockFetch.mock.calls[0][1].headers['Authorization']).toBe('Bearer secret');
+    });
+
+    it('throws when KoboldCpp returns an error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Bad Request',
+        json: async () => ({ msg: 'something broke' })
+      });
+      await expect(provider.generate('s', 'u')).rejects.toThrow('something broke');
+    });
+
+    it('handles empty results array gracefully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [] })
+      });
+      const result = await provider.generate('s', 'u');
+      expect(result.content).toBe('');
+    });
+  });
+
+  describe('Stream Parsing', () => {
+    it('yields token content for each SSE message event', async () => {
+      const body = streamFrom([
+        'event: message\ndata: {"token": "Hello"}\n\n',
+        'event: message\ndata: {"token": " world"}\n\n'
+      ]);
+      const chunks = await collectStream(provider.parseStreamResponse(body));
+      const contents = chunks.filter(c => c.content).map(c => c.content);
+      expect(contents).toEqual(['Hello', ' world']);
+      expect(chunks[chunks.length - 1].finished).toBe(true);
+    });
+
+    it('handles events split across read chunks', async () => {
+      const body = streamFrom([
+        'event: message\ndata: {"tok',
+        'en": "split"}\n\nevent: message\ndata: {"token": "ok"}\n\n'
+      ]);
+      const chunks = await collectStream(provider.parseStreamResponse(body));
+      const contents = chunks.filter(c => c.content).map(c => c.content);
+      expect(contents).toEqual(['split', 'ok']);
+    });
+
+    it('terminates on finish_reason', async () => {
+      const body = streamFrom([
+        'event: message\ndata: {"token": "x"}\n\n',
+        'event: message\ndata: {"token": "", "finish_reason": "stop"}\n\n',
+        'event: message\ndata: {"token": "after-finish"}\n\n'
+      ]);
+      const chunks = await collectStream(provider.parseStreamResponse(body));
+      const contents = chunks.filter(c => c.content).map(c => c.content);
+      expect(contents).toEqual(['x']);
+      expect(chunks.at(-1).finished).toBe(true);
+    });
+
+    it('skips malformed data lines without crashing', async () => {
+      const body = streamFrom([
+        'event: message\ndata: {not valid json}\n\n',
+        'event: message\ndata: {"token": "good"}\n\n'
+      ]);
+      const chunks = await collectStream(provider.parseStreamResponse(body));
+      const contents = chunks.filter(c => c.content).map(c => c.content);
+      expect(contents).toEqual(['good']);
+    });
+  });
+
+  describe('Streaming Generation + Abort', () => {
+    it('POSTs to /api/extra/generate/stream and returns stream + abort', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: streamFrom(['event: message\ndata: {"token": "hi"}\n\n'])
+      });
+
+      const result = await provider.generateStreaming('s', 'u');
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:5001/api/extra/generate/stream');
+      expect(typeof result.abort).toBe('function');
+      expect(result.metadata.genkey).toMatch(/^KCPP_/);
+
+      const chunks = await collectStream(result.stream);
+      expect(chunks.some(c => c.content === 'hi')).toBe(true);
+    });
+
+    it('fires POST /api/extra/abort with genkey when caller signal aborts', async () => {
+      const controller = new AbortController();
+
+      // First call: stream request. Second call: the abort POST.
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          body: streamFrom([])
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({})
+        });
+
+      const result = await provider.generateStreaming('s', 'u', { signal: controller.signal });
+      const genkey = result.metadata.genkey;
+
+      controller.abort();
+
+      // Give the abort handler a tick to fire
+      await new Promise((r) => setImmediate(r));
+
+      const abortCall = mockFetch.mock.calls[1];
+      expect(abortCall).toBeDefined();
+      expect(abortCall[0]).toBe('http://localhost:5001/api/extra/abort');
+      expect(JSON.parse(abortCall[1].body)).toEqual({ genkey });
+    });
+
+    it('throws when stream endpoint returns error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Unauthorized',
+        json: async () => ({ msg: 'bad password' })
+      });
+      await expect(provider.generateStreaming('s', 'u')).rejects.toThrow('bad password');
+    });
+  });
+
+  describe('getCurrentModel', () => {
+    it('returns data.result from /api/v1/model', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 'koboldcpp/Llama-3-8B' })
+      });
+      const model = await provider.getCurrentModel();
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:5001/api/v1/model');
+      expect(model).toBe('koboldcpp/Llama-3-8B');
+    });
+
+    it('returns empty string when result missing', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+      expect(await provider.getCurrentModel()).toBe('');
+    });
+
+    it('throws when endpoint unreachable', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
+        json: async () => ({})
+      });
+      await expect(provider.getCurrentModel()).rejects.toThrow('Failed to fetch model');
+    });
+  });
+
+  describe('getMaxContextLength', () => {
+    it('returns numeric value from /api/extra/true_max_context_length', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: 8192 })
+      });
+      const ctx = await provider.getMaxContextLength();
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:5001/api/extra/true_max_context_length');
+      expect(ctx).toBe(8192);
+    });
+
+    it('returns null when value is missing or non-numeric', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+      expect(await provider.getMaxContextLength()).toBeNull();
+    });
+  });
+
+  describe('getMaxLength', () => {
+    it('returns numeric value from /api/v1/config/max_length', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: 512 })
+      });
+      const len = await provider.getMaxLength();
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:5001/api/v1/config/max_length');
+      expect(len).toBe(512);
+    });
+
+    it('returns null when value is missing or non-numeric', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+      expect(await provider.getMaxLength()).toBeNull();
+    });
+  });
+
+  describe('getEndpointInfo', () => {
+    it('returns model + maxContextLength + maxLength when all endpoints succeed', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'M' }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ value: 16384 }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ value: 512 }) });
+      const info = await provider.getEndpointInfo();
+      expect(info).toEqual({ model: 'M', maxContextLength: 16384, maxLength: 512 });
+    });
+
+    it('still returns model when both limit endpoints fail (best-effort)', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'M' }) })
+        .mockResolvedValueOnce({ ok: false, statusText: 'Not Found', json: async () => ({}) })
+        .mockResolvedValueOnce({ ok: false, statusText: 'Not Found', json: async () => ({}) });
+      const info = await provider.getEndpointInfo();
+      expect(info).toEqual({ model: 'M', maxContextLength: null, maxLength: null });
+    });
+
+    it('returns partial info when only one limit endpoint succeeds', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 'M' }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ value: 8192 }) })
+        .mockResolvedValueOnce({ ok: false, statusText: 'Not Found', json: async () => ({}) });
+      const info = await provider.getEndpointInfo();
+      expect(info).toEqual({ model: 'M', maxContextLength: 8192, maxLength: null });
+    });
+  });
+
+  describe('Error Parsing', () => {
+    it('maps 401 to AUTH_ERROR', () => {
+      const err = provider.parseError(new Error('Request failed: 401 Unauthorized'));
+      expect(err.code).toBe('AUTH_ERROR');
+    });
+
+    it('maps ECONNREFUSED to CONNECTION_ERROR', () => {
+      const err = provider.parseError(new Error('ECONNREFUSED'));
+      expect(err.code).toBe('CONNECTION_ERROR');
+      expect(err.message).toContain('http://localhost:5001');
+    });
+
+    it('falls through to default for unknown errors', () => {
+      const err = provider.parseError(new Error('something else'));
+      expect(err.code).toBe('API_ERROR');
+    });
+  });
+
+  describe('Genkey', () => {
+    it('generates unique keys with KCPP_ prefix', () => {
+      const a = provider.generateGenkey();
+      const b = provider.generateGenkey();
+      expect(a).toMatch(/^KCPP_/);
+      expect(b).toMatch(/^KCPP_/);
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/server/src/services/providers/koboldcpp-provider.js
+++ b/server/src/services/providers/koboldcpp-provider.js
@@ -1,0 +1,337 @@
+/**
+ * KoboldCpp Provider Implementation
+ * Talks to KoboldCpp's native API (not the OpenAI shim) so we get access to
+ * its full sampler surface, dedicated streaming endpoint, and genkey-based abort.
+ * API Docs: https://lite.koboldai.net/koboldcpp_api
+ */
+
+import { LLMProvider } from './base-provider.js';
+
+const DEFAULT_BASE_URL = 'http://localhost:5001/api';
+const DEFAULT_MAX_TOKENS = 200;
+const DEFAULT_MAX_CONTEXT = 4096;
+
+/**
+ * Normalize a user-provided baseURL so it works whether or not they include the
+ * trailing `/api`. Kobold's own docs and KoboldAI Lite tell users to enter the
+ * URL with `/api`, but tools like ooba omit it — accept both.
+ */
+function normalizeBaseURL(raw) {
+  let url = (raw || DEFAULT_BASE_URL).trim().replace(/\/+$/, '');
+  if (url.toLowerCase().endsWith('/api')) {
+    url = url.slice(0, -4);
+  }
+  return url;
+}
+
+export class KoboldCppProvider extends LLMProvider {
+  constructor(config) {
+    const koboldConfig = {
+      ...config,
+      baseURL: normalizeBaseURL(config.baseURL),
+      model: config.model || ''
+    };
+
+    super(koboldConfig);
+
+    this.password = config.password || '';
+  }
+
+  getCapabilities() {
+    return {
+      streaming: true,
+      reasoning: false,
+      visionAPI: false,
+      maxContextWindow: 8192
+    };
+  }
+
+  validateConfig() {
+    if (!this.baseURL || this.baseURL.trim() === '') {
+      return { valid: false, error: 'Base URL is required' };
+    }
+    return { valid: true };
+  }
+
+  authHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    if (this.password) {
+      headers['Authorization'] = `Bearer ${this.password}`;
+    }
+    return headers;
+  }
+
+  generateGenkey() {
+    return `KCPP_${Math.random().toString(36).slice(2, 12)}`;
+  }
+
+  /**
+   * Build the native /api/v1/generate request body.
+   * System prompt goes in `memory` (Kobold preserves it from truncation),
+   * user prompt goes in `prompt`.
+   */
+  buildRequestBody(systemPrompt, userPrompt, options = {}, genkey = null) {
+    const body = {
+      prompt: userPrompt || '',
+      memory: systemPrompt || '',
+      max_length: options.maxTokens ?? DEFAULT_MAX_TOKENS,
+      max_context_length: options.maxContextTokens ?? DEFAULT_MAX_CONTEXT,
+      temperature: options.temperature ?? 0.7,
+      use_default_badwordsids: true,
+      trim_stop: true
+    };
+
+    if (genkey) body.genkey = genkey;
+
+    const passthrough = [
+      'top_p', 'top_k', 'top_a', 'typical', 'tfs', 'min_p',
+      'rep_pen', 'rep_pen_range', 'rep_pen_slope',
+      'sampler_order', 'mirostat', 'mirostat_tau', 'mirostat_eta'
+    ];
+    for (const key of passthrough) {
+      if (options[key] !== null && options[key] !== undefined) {
+        body[key] = options[key];
+      }
+    }
+
+    if (options.stop_sequences && options.stop_sequences.length > 0) {
+      body.stop_sequence = options.stop_sequences;
+    }
+
+    return body;
+  }
+
+  async generate(systemPrompt, userPrompt, options = {}) {
+    const genkey = this.generateGenkey();
+    const body = this.buildRequestBody(systemPrompt, userPrompt, options, genkey);
+
+    const response = await fetch(`${this.baseURL}/api/v1/generate`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+      signal: options.signal
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        errorData.detail?.msg || errorData.msg || `KoboldCpp request failed: ${response.statusText}`
+      );
+    }
+
+    const data = await response.json();
+    const text = data.results?.[0]?.text ?? '';
+
+    return {
+      content: text,
+      reasoning: '',
+      usage: undefined,
+      metadata: { genkey }
+    };
+  }
+
+  async generateStreaming(systemPrompt, userPrompt, options = {}) {
+    const genkey = this.generateGenkey();
+    const body = this.buildRequestBody(systemPrompt, userPrompt, options, genkey);
+
+    const controller = new AbortController();
+    const signal = options.signal || controller.signal;
+
+    // When the caller aborts, also tell Kobold to stop generating server-side.
+    // Without this, the fetch disconnects but Kobold keeps producing tokens.
+    const onAbort = () => {
+      this.sendAbort(genkey).catch((err) => {
+        console.warn('[KoboldCpp] Failed to send abort:', err.message);
+      });
+    };
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    const response = await fetch(`${this.baseURL}/api/extra/generate/stream`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify(body),
+      signal
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        errorData.detail?.msg || errorData.msg || `KoboldCpp stream request failed: ${response.statusText}`
+      );
+    }
+
+    return {
+      stream: this.parseStreamResponse(response.body),
+      abort: () => {
+        controller.abort();
+      },
+      metadata: { genkey, userPrompt, systemPrompt }
+    };
+  }
+
+  /**
+   * Parse KoboldCpp's SSE format:
+   *   event: message
+   *   data: {"token": "..."}
+   *
+   * Events are separated by blank lines. The connection closing signals completion.
+   */
+  async *parseStreamResponse(body) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // SSE events are separated by blank lines
+        let sepIdx;
+        while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
+          const event = buffer.slice(0, sepIdx);
+          buffer = buffer.slice(sepIdx + 2);
+
+          let dataLine = null;
+          for (const rawLine of event.split('\n')) {
+            const line = rawLine.replace(/\r$/, '');
+            if (line.startsWith('data:')) {
+              dataLine = line.slice(5).trimStart();
+            }
+          }
+          if (!dataLine) continue;
+
+          try {
+            const data = JSON.parse(dataLine);
+            const token = data.token ?? '';
+            if (token) {
+              yield { content: token, finished: false };
+            }
+            if (data.finish_reason) {
+              yield { content: null, finished: true };
+              return;
+            }
+          } catch (err) {
+            console.warn('[KoboldCpp] Failed to parse SSE event:', err.message);
+          }
+        }
+      }
+    } catch (error) {
+      if (error.name !== 'AbortError') throw error;
+      console.log('[KoboldCpp] Stream aborted by client');
+    } finally {
+      reader.releaseLock();
+    }
+
+    yield { content: null, finished: true };
+  }
+
+  async sendAbort(genkey) {
+    if (!genkey) return;
+    const response = await fetch(`${this.baseURL}/api/extra/abort`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify({ genkey })
+    });
+    if (!response.ok) {
+      throw new Error(`Abort request failed: ${response.statusText}`);
+    }
+  }
+
+  /**
+   * Fetch the currently loaded model name from /api/v1/model.
+   * Returns the bare model identifier (Kobold prefixes it with "koboldcpp/").
+   */
+  async getCurrentModel() {
+    const response = await fetch(`${this.baseURL}/api/v1/model`, {
+      method: 'GET',
+      headers: this.authHeaders()
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch model: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data.result || '';
+  }
+
+  /**
+   * Fetch the actual context window Kobold allocated memory for. This is the real
+   * ceiling clients must stay under (the `--contextsize` flag is what the operator
+   * *asked for*; the "true" endpoint returns what Kobold actually ended up with).
+   * Returns the integer value, or null if the endpoint is unavailable.
+   */
+  async getMaxContextLength() {
+    const response = await fetch(`${this.baseURL}/api/extra/true_max_context_length`, {
+      method: 'GET',
+      headers: this.authHeaders()
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch max context length: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return typeof data.value === 'number' ? data.value : null;
+  }
+
+  /**
+   * Fetch the configured per-request max generation tokens (--defaultgenamt).
+   * Returns the integer value, or null if the endpoint is unavailable.
+   */
+  async getMaxLength() {
+    const response = await fetch(`${this.baseURL}/api/v1/config/max_length`, {
+      method: 'GET',
+      headers: this.authHeaders()
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch max length: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return typeof data.value === 'number' ? data.value : null;
+  }
+
+  /**
+   * Fetch model name + Kobold's operator-set ceilings (max context + max generation)
+   * in one call, used by the "Detect" UI flow. The two ceiling fetches are
+   * best-effort: if either endpoint fails, model is still returned.
+   */
+  async getEndpointInfo() {
+    const model = await this.getCurrentModel();
+    let maxContextLength = null;
+    let maxLength = null;
+    try {
+      maxContextLength = await this.getMaxContextLength();
+    } catch (err) {
+      console.warn('[KoboldCpp] Could not fetch true_max_context_length:', err.message);
+    }
+    try {
+      maxLength = await this.getMaxLength();
+    } catch (err) {
+      console.warn('[KoboldCpp] Could not fetch max_length:', err.message);
+    }
+    return { model, maxContextLength, maxLength };
+  }
+
+  parseError(error) {
+    const msg = error.message || '';
+    if (msg.includes('401') || msg.toLowerCase().includes('unauthorized')) {
+      return {
+        code: 'AUTH_ERROR',
+        message: 'Wrong password, or endpoint requires --password',
+        original: error
+      };
+    }
+    if (msg.includes('ECONNREFUSED') || msg.includes('fetch failed') || error.cause?.code === 'ECONNREFUSED') {
+      return {
+        code: 'CONNECTION_ERROR',
+        message: `Could not reach KoboldCpp at ${this.baseURL}`,
+        original: error
+      };
+    }
+    return super.parseError(error);
+  }
+}

--- a/vue_client/src/components/PresetEditorModal.vue
+++ b/vue_client/src/components/PresetEditorModal.vue
@@ -176,8 +176,13 @@ onMounted(async () => {
 })
 
 const canSave = computed(() => {
+  const apiConfig = formData.value.apiConfig || {}
+  // KoboldCpp authenticates with a URL (and optional password), not an API key
+  if (formData.value.provider === 'koboldcpp') {
+    return formData.value.name.trim() && (apiConfig.baseURL || '').trim() !== ''
+  }
   // AI Horde uses "0000000000" as default anonymous key, so it's always valid
-  const hasValidApiKey = formData.value.apiConfig.apiKey.trim() !== ''
+  const hasValidApiKey = (apiConfig.apiKey || '').trim() !== ''
   return formData.value.name.trim() && hasValidApiKey
 })
 

--- a/vue_client/src/components/providers/KoboldCppConfig.vue
+++ b/vue_client/src/components/providers/KoboldCppConfig.vue
@@ -1,0 +1,261 @@
+<template>
+  <BaseProviderConfig
+    :config="config"
+    @update:config="$emit('update:config', $event)"
+    :show-max-context="true"
+    :context-range="{ min: 1024, max: 32768 }"
+    :context-help-text="`Context window size in tokens. Should match the context length KoboldCpp was launched with.`"
+    provider="koboldcpp"
+    :model="localApiConfig.model || ''"
+  >
+    <template #api-config>
+      <div class="form-group">
+        <label for="koboldBaseURL">Base URL</label>
+        <input
+          id="koboldBaseURL"
+          v-model="localApiConfig.baseURL"
+          type="text"
+          class="text-input"
+          placeholder="http://localhost:5001/api"
+        />
+        <small class="help-text">
+          URL of your running KoboldCpp instance (default port 5001). The trailing <code>/api</code>
+          is optional. If Writer's Guild runs in Docker and KoboldCpp runs on the host or another
+          machine, use that host's IP or <code>host.docker.internal</code> instead of localhost.
+        </small>
+      </div>
+
+      <div class="form-group">
+        <label for="koboldPassword">Password <span class="optional">(optional)</span></label>
+        <input
+          id="koboldPassword"
+          v-model="localApiConfig.password"
+          type="password"
+          class="text-input"
+          placeholder="Leave empty if KoboldCpp has no --password set"
+        />
+        <small class="help-text">Only needed if KoboldCpp was launched with <code>--password</code>.</small>
+      </div>
+
+      <div class="form-group">
+        <label>Loaded Model</label>
+        <div class="model-row">
+          <button
+            type="button"
+            class="btn btn-secondary btn-small"
+            @click="detectEndpoint"
+            :disabled="detecting || !localApiConfig.baseURL"
+          >
+            <i :class="detecting ? 'fas fa-spinner fa-spin' : 'fas fa-sync'"></i>
+            {{ detecting ? 'Detecting...' : 'Detect Settings' }}
+          </button>
+          <span v-if="localApiConfig.model" class="model-name">{{ localApiConfig.model }}</span>
+          <span v-else class="model-name model-empty">Not detected yet</span>
+        </div>
+        <div v-if="detectError" class="error-message">{{ detectError }}</div>
+        <small class="help-text">
+          Confirms the endpoint is reachable, then pulls the loaded model name plus Kobold's
+          configured max context window and max generation length into the form below.
+        </small>
+      </div>
+    </template>
+  </BaseProviderConfig>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import BaseProviderConfig from './shared/BaseProviderConfig.vue'
+import { presetsAPI } from '../../services/api'
+import { useToast } from '../../composables/useToast'
+
+const props = defineProps({
+  config: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:config'])
+
+const toast = useToast()
+
+const detecting = ref(false)
+const detectError = ref(null)
+
+const localApiConfig = computed({
+  get() {
+    return props.config.apiConfig || {}
+  },
+  set(value) {
+    emit('update:config', { ...props.config, apiConfig: value })
+  }
+})
+
+async function detectEndpoint() {
+  try {
+    detecting.value = true
+    detectError.value = null
+    const response = await presetsAPI.getKoboldCppInfo(
+      localApiConfig.value.baseURL,
+      localApiConfig.value.password
+    )
+    const modelName = response.model || ''
+    const maxContext = response.maxContextLength
+    const maxLength = response.maxLength
+
+    // Emit a single update so reactive computed props in the parent pick up everything.
+    const nextConfig = {
+      ...props.config,
+      apiConfig: { ...(props.config.apiConfig || {}), model: modelName }
+    }
+    const nextGenSettings = { ...(props.config.generationSettings || {}) }
+    let touched = false
+    if (typeof maxContext === 'number' && maxContext > 0) {
+      nextGenSettings.maxContextTokens = maxContext
+      touched = true
+    }
+    if (typeof maxLength === 'number' && maxLength > 0) {
+      nextGenSettings.maxTokens = maxLength
+      touched = true
+    }
+    if (touched) nextConfig.generationSettings = nextGenSettings
+    emit('update:config', nextConfig)
+
+    const parts = []
+    if (modelName) parts.push(`Model: ${modelName}`)
+    if (typeof maxContext === 'number') parts.push(`Max context: ${maxContext}`)
+    if (typeof maxLength === 'number') parts.push(`Max gen: ${maxLength}`)
+    if (parts.length > 0) {
+      toast.success(`Connected. ${parts.join(' · ')}`)
+    } else {
+      toast.success('Connected, but KoboldCpp did not report model or limits.')
+    }
+  } catch (error) {
+    detectError.value = error.message || 'Failed to reach KoboldCpp'
+    console.error('Failed to inspect KoboldCpp endpoint:', error)
+  } finally {
+    detecting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.optional {
+  font-weight: 400;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.text-input {
+  width: 100%;
+  padding: 0.6rem;
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.help-text {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.help-text code {
+  background-color: var(--bg-tertiary);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+
+.model-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.model-name {
+  font-family: monospace;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  padding: 0.3rem 0.6rem;
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.model-name.model-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.btn {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.btn-secondary {
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+
+.btn-secondary:hover {
+  background-color: var(--bg-quaternary);
+}
+
+.btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-small {
+  padding: 0.5rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.error-message {
+  margin-top: 0.5rem;
+  padding: 0.6rem;
+  background-color: #fee;
+  border: 1px solid #fcc;
+  border-radius: 4px;
+  color: #c33;
+  font-size: 0.9rem;
+}
+
+.fa-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/vue_client/src/components/providers/index.js
+++ b/vue_client/src/components/providers/index.js
@@ -8,6 +8,7 @@ import AIHordeConfig from './AIHordeConfig.vue'
 import OpenAIConfig from './OpenAIConfig.vue'
 import AnthropicConfig from './AnthropicConfig.vue'
 import OpenRouterConfig from './OpenRouterConfig.vue'
+import KoboldCppConfig from './KoboldCppConfig.vue'
 
 // Re-export consolidated provider metadata from config
 export { PROVIDERS } from '../../config/providerDefaults'
@@ -17,7 +18,8 @@ export const PROVIDER_COMPONENTS = {
   aihorde: AIHordeConfig,
   openai: OpenAIConfig,
   anthropic: AnthropicConfig,
-  openrouter: OpenRouterConfig
+  openrouter: OpenRouterConfig,
+  koboldcpp: KoboldCppConfig
 }
 
 /**

--- a/vue_client/src/components/providers/shared/AdvancedSamplingSettings.vue
+++ b/vue_client/src/components/providers/shared/AdvancedSamplingSettings.vue
@@ -116,9 +116,9 @@
       </small>
     </div>
 
-    <!-- AI Horde Specific Parameters -->
-    <template v-if="provider === 'aihorde'">
-      <h4 class="subsection-title">AI Horde Samplers</h4>
+    <!-- Llama.cpp-style samplers (AI Horde + KoboldCpp) -->
+    <template v-if="['aihorde', 'koboldcpp'].includes(provider)">
+      <h4 class="subsection-title">Sampler Settings</h4>
 
       <div class="form-group">
         <label for="rep_pen">
@@ -235,6 +235,72 @@
         </small>
       </div>
     </template>
+
+    <!-- KoboldCpp-only: Mirostat -->
+    <template v-if="provider === 'koboldcpp'">
+      <h4 class="subsection-title">Mirostat</h4>
+
+      <div class="form-group">
+        <label for="mirostat">Mirostat Mode</label>
+        <div class="input-with-clear">
+          <select
+            id="mirostat"
+            v-model.number="localSettings.mirostat"
+            class="text-input"
+          >
+            <option :value="null">Default (off)</option>
+            <option :value="0">0 — Disabled</option>
+            <option :value="1">1 — Mirostat v1</option>
+            <option :value="2">2 — Mirostat v2</option>
+          </select>
+        </div>
+        <small class="help-text">
+          Adaptive sampling that targets a fixed perplexity. Replaces top_k/top_p when enabled.
+        </small>
+      </div>
+
+      <div v-if="localSettings.mirostat" class="form-group">
+        <label for="mirostat_tau">
+          Mirostat Tau: {{ localSettings.mirostat_tau != null ? localSettings.mirostat_tau.toFixed(2) : 'Default (5.0)' }}
+        </label>
+        <div class="input-with-clear">
+          <input
+            id="mirostat_tau"
+            v-model.number="localSettings.mirostat_tau"
+            type="range"
+            min="0"
+            max="10"
+            step="0.1"
+            class="range-input"
+          />
+          <button v-if="localSettings.mirostat_tau != null" @click="localSettings.mirostat_tau = null" class="clear-btn">
+            Clear
+          </button>
+        </div>
+        <small class="help-text">Target entropy (0-10). Lower = more focused output.</small>
+      </div>
+
+      <div v-if="localSettings.mirostat" class="form-group">
+        <label for="mirostat_eta">
+          Mirostat Eta: {{ localSettings.mirostat_eta != null ? localSettings.mirostat_eta.toFixed(2) : 'Default (0.1)' }}
+        </label>
+        <div class="input-with-clear">
+          <input
+            id="mirostat_eta"
+            v-model.number="localSettings.mirostat_eta"
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            class="range-input"
+          />
+          <button v-if="localSettings.mirostat_eta != null" @click="localSettings.mirostat_eta = null" class="clear-btn">
+            Clear
+          </button>
+        </div>
+        <small class="help-text">Learning rate (0-1). How fast Mirostat adjusts to hit Tau.</small>
+      </div>
+    </template>
   </section>
 </template>
 
@@ -260,11 +326,11 @@ const emit = defineEmits(['update:modelValue'])
 
 // Provider capability checks
 const supportsTopP = computed(() => {
-  return ['anthropic', 'openai', 'deepseek', 'openrouter', 'aihorde'].includes(props.provider)
+  return ['anthropic', 'openai', 'deepseek', 'openrouter', 'aihorde', 'koboldcpp'].includes(props.provider)
 })
 
 const supportsTopK = computed(() => {
-  return ['anthropic', 'deepseek', 'aihorde'].includes(props.provider)
+  return ['anthropic', 'deepseek', 'aihorde', 'koboldcpp'].includes(props.provider)
 })
 
 const supportsFrequencyPenalty = computed(() => {

--- a/vue_client/src/config/providerDefaults.js
+++ b/vue_client/src/config/providerDefaults.js
@@ -182,6 +182,58 @@ export const PROVIDERS = {
     }
   },
 
+  koboldcpp: {
+    // Display information
+    name: 'KoboldCpp',
+    description: 'Local KoboldCpp endpoint (native API)',
+    icon: 'fa-server',
+    // Capabilities
+    supportsReasoning: false,
+    supportsStreaming: true,
+    // Default configuration
+    defaults: {
+      provider: 'koboldcpp',
+      apiConfig: {
+        baseURL: 'http://localhost:5001/api',
+        password: '',
+        model: ''
+      },
+      generationSettings: {
+        maxTokens: 200,
+        temperature: 0.7,
+        maxContextTokens: 4096,
+        includeDialogueExamples: false,
+        // KoboldCpp-tunable samplers (null = use Kobold defaults)
+        top_p: null,
+        top_k: null,
+        top_a: null,
+        typical: null,
+        tfs: null,
+        min_p: null,
+        rep_pen: null,
+        rep_pen_range: null,
+        rep_pen_slope: null,
+        // Mirostat (KoboldCpp-specific)
+        mirostat: null,
+        mirostat_tau: null,
+        mirostat_eta: null
+      },
+      lorebookSettings: {
+        scanDepth: 2000,
+        tokenBudget: 1800,
+        recursionDepth: 3,
+        enableRecursion: true
+      },
+      promptTemplates: {
+        systemPrompt: null,
+        continue: null,
+        character: null,
+        instruction: null,
+        rewriteThirdPerson: null
+      }
+    }
+  },
+
   openrouter: {
     // Display information
     name: 'OpenRouter',

--- a/vue_client/src/services/api.js
+++ b/vue_client/src/services/api.js
@@ -655,6 +655,13 @@ export const presetsAPI = {
     return request(`/presets/deepseek/models?apiKey=${encodeURIComponent(apiKey)}`)
   },
 
+  // KoboldCpp specific methods
+  getKoboldCppInfo(baseURL, password = '') {
+    const params = new URLSearchParams({ baseURL })
+    if (password) params.set('password', password)
+    return request(`/presets/koboldcpp/info?${params.toString()}`)
+  },
+
   // Get default prompt templates (single source of truth from server)
   getDefaultTemplates() {
     return request('/presets/defaults/templates')
@@ -674,10 +681,10 @@ export const onboardingAPI = {
     })
   },
 
-  createPreset(provider, apiKey) {
+  createPreset(provider, apiKey, extraConfig = {}) {
     return request('/onboarding/preset', {
       method: 'POST',
-      body: JSON.stringify({ provider, apiKey }),
+      body: JSON.stringify({ provider, apiKey, ...extraConfig }),
     })
   },
 

--- a/vue_client/src/views/OnboardingWizard.vue
+++ b/vue_client/src/views/OnboardingWizard.vue
@@ -109,7 +109,7 @@
           </div>
         </div>
 
-        <div v-if="selectedProvider && selectedProvider !== 'aihorde'" class="form-group">
+        <div v-if="selectedProvider && selectedProvider !== 'aihorde' && selectedProvider !== 'koboldcpp'" class="form-group">
           <label :for="'apiKey-' + selectedProvider">
             {{ getProviderName(selectedProvider) }} API Key
           </label>
@@ -142,6 +142,31 @@
             but generation may be slower during peak times.
           </p>
         </div>
+
+        <template v-if="selectedProvider === 'koboldcpp'">
+          <div class="form-group">
+            <label for="koboldcpp-baseURL">KoboldCpp URL</label>
+            <input
+              id="koboldcpp-baseURL"
+              v-model="koboldBaseURL"
+              type="text"
+              placeholder="http://localhost:5001/api"
+            />
+            <p class="help-text">
+              URL of your running KoboldCpp instance. If Writer's Guild is running in Docker
+              and KoboldCpp is on the host or another machine, use that host's IP.
+            </p>
+          </div>
+          <div class="form-group">
+            <label for="koboldcpp-password">Password <span class="optional-label">(optional)</span></label>
+            <input
+              id="koboldcpp-password"
+              v-model="koboldPassword"
+              type="password"
+              placeholder="Only if KoboldCpp was started with --password"
+            />
+          </div>
+        </template>
 
         <div class="button-group">
           <button class="btn btn-secondary" @click="prevStep">Back</button>
@@ -278,6 +303,8 @@ const persona = ref({
 // Step 3: Provider
 const selectedProvider = ref('deepseek')
 const apiKey = ref('')
+const koboldBaseURL = ref('http://localhost:5001/api')
+const koboldPassword = ref('')
 
 const providers = [
   {
@@ -305,6 +332,11 @@ const providers = [
     id: 'aihorde',
     name: 'AI Horde',
     description: 'Free, community-powered AI. No API key required.'
+  },
+  {
+    id: 'koboldcpp',
+    name: 'KoboldCpp',
+    description: 'Connect to a local KoboldCpp endpoint you\'re already running.'
   }
 ]
 
@@ -317,6 +349,7 @@ const setupSummary = ref(null)
 const canProceedFromProvider = computed(() => {
   if (!selectedProvider.value) return false
   if (selectedProvider.value === 'aihorde') return true
+  if (selectedProvider.value === 'koboldcpp') return koboldBaseURL.value.trim().length > 0
   return apiKey.value.trim().length > 0
 })
 
@@ -391,7 +424,12 @@ async function createPreset() {
     return
   }
 
-  if (selectedProvider.value !== 'aihorde' && !apiKey.value.trim()) {
+  if (selectedProvider.value === 'koboldcpp') {
+    if (!koboldBaseURL.value.trim()) {
+      toast.error('Please enter a URL for your KoboldCpp endpoint')
+      return
+    }
+  } else if (selectedProvider.value !== 'aihorde' && !apiKey.value.trim()) {
     toast.error('Please enter your API key')
     return
   }
@@ -400,9 +438,13 @@ async function createPreset() {
   loadingMessage.value = 'Configuring AI provider...'
 
   try {
+    const extraConfig = selectedProvider.value === 'koboldcpp'
+      ? { baseURL: koboldBaseURL.value.trim(), password: koboldPassword.value.trim() }
+      : {}
     const result = await onboardingAPI.createPreset(
       selectedProvider.value,
-      apiKey.value.trim()
+      apiKey.value.trim(),
+      extraConfig
     )
     setupSummary.value = {
       ...setupSummary.value,

--- a/vue_client/src/views/__tests__/OnboardingWizard.test.js
+++ b/vue_client/src/views/__tests__/OnboardingWizard.test.js
@@ -182,9 +182,9 @@ describe('OnboardingWizard', () => {
       await flushPromises()
     })
 
-    it('should show all 5 provider options', () => {
+    it('should show all provider options', () => {
       const providers = wrapper.findAll('.provider-option')
-      expect(providers).toHaveLength(5)
+      expect(providers).toHaveLength(6)
     })
 
     it('should have DeepSeek selected by default', () => {
@@ -233,7 +233,7 @@ describe('OnboardingWizard', () => {
       await wrapper.findAll('.button-group button')[1].trigger('click')
       await flushPromises()
 
-      expect(mockOnboardingAPI.createPreset).toHaveBeenCalledWith('deepseek', 'sk-test-key')
+      expect(mockOnboardingAPI.createPreset).toHaveBeenCalledWith('deepseek', 'sk-test-key', {})
     })
 
     it('should advance to step 4 after successful preset creation', async () => {


### PR DESCRIPTION
## Summary
- Adds a first-class `koboldcpp` provider that hits KoboldCpp's native API directly (rather than the OpenAI compatibility shim), exposing streaming generation with `genkey`-based abort, the full sampler surface (rep_pen, rep_pen_range, top_a, typical, tfs, min_p, plus mirostat mode/tau/eta), optional `--password` Bearer auth, and live endpoint introspection.
- Detect Settings button on the preset editor pulls the loaded model name + Kobold's true max context window + max generation length from `/api/v1/model`, `/api/extra/true_max_context_length`, and `/api/v1/config/max_length` and autofills them into the form. Each limit fetch is best-effort so older Kobold builds still get partial info.
- KoboldCpp is selectable in the onboarding wizard with a URL + optional password form (no API key). URLs with or without a trailing `/api` are normalized so users can paste whatever they see in Kobold's terminal output.
- System prompt goes in Kobold's `memory` field so it isn't truncated; user prompt goes in `prompt`. Abort hooks `AbortSignal` to also POST `/api/extra/abort` with the request's `genkey`, so generation actually stops server-side instead of just disconnecting.

Addresses #17 — adds native KoboldCpp support rather than requiring users to configure the OpenAI preset with a custom endpoint.

## Test plan
- [x] Server unit tests pass (746 total, 46 new in `koboldcpp-provider.test.js`)
- [x] Client tests pass (191 total)
- [x] Client builds clean
- [x] Onboard with KoboldCpp option → URL + optional password form appears
- [x] Detect Settings populates loaded model, max context, max generation length
- [x] Story continuation streams tokens incrementally against a real KoboldCpp instance
- [x] Cancel mid-generation verifies abort actually stops Kobold (not just disconnect)
- [x] Toggle mirostat mode = 2 → confirm in Kobold's console that `mirostat: 2` shows up in request params
- [x] Restart Kobold with `--password testpass` → wrong/missing password produces a clear error toast; correct password works
- [x] Regression: existing AI Horde preset still works (the rep_pen/top_a/typical/tfs block is now shared with KoboldCpp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)