### PR TITLE
Add OpenAI-Compatible provider for local LLM endpoints

### DIFF
--- a/server/src/routes/onboarding.js
+++ b/server/src/routes/onboarding.js
@@ -99,20 +99,22 @@ router.post('/preset', asyncHandler(async (req, res) => {
     throw new AppError('Provider is required', 400);
   }
 
-  const validProviders = ['deepseek', 'openai', 'anthropic', 'openrouter', 'aihorde', 'koboldcpp', 'ollama'];
+  const validProviders = ['deepseek', 'openai', 'anthropic', 'openrouter', 'aihorde', 'koboldcpp', 'ollama', 'openaicompatible'];
   if (!validProviders.includes(provider)) {
     throw new AppError(`Invalid provider. Must be one of: ${validProviders.join(', ')}`, 400);
   }
 
-  // AI Horde, KoboldCpp, and Ollama don't require an API key
-  const providersWithoutApiKey = ['aihorde', 'koboldcpp', 'ollama'];
+  // AI Horde, KoboldCpp, Ollama, and OpenAI Compatible don't require an API key
+  const providersWithoutApiKey = ['aihorde', 'koboldcpp', 'ollama', 'openaicompatible'];
   if (!providersWithoutApiKey.includes(provider) && (!apiKey || !apiKey.trim())) {
     throw new AppError('API key is required for this provider', 400);
   }
 
-  // KoboldCpp and Ollama require a base URL
-  if (['koboldcpp', 'ollama'].includes(provider) && (!baseURL || !baseURL.trim())) {
-    throw new AppError(`Base URL is required for ${provider === 'koboldcpp' ? 'KoboldCpp' : 'Ollama'}`, 400);
+  // KoboldCpp, Ollama, and OpenAI Compatible require a base URL
+  const providersRequiringBaseURL = ['koboldcpp', 'ollama', 'openaicompatible'];
+  if (providersRequiringBaseURL.includes(provider) && (!baseURL || !baseURL.trim())) {
+    const labels = { koboldcpp: 'KoboldCpp', ollama: 'Ollama', openaicompatible: 'OpenAI Compatible' };
+    throw new AppError(`Base URL is required for ${labels[provider]}`, 400);
   }
 
   // Basic API key validation
@@ -367,6 +369,26 @@ function getProviderPresetConfig(provider, apiKey, extraConfig = {}) {
         generationSettings: {
           maxTokens: 200,
           maxContextTokens: 4096,
+          temperature: 0.7,
+          includeDialogueExamples: false,
+          stop_sequences: []
+        },
+        lorebookSettings: baseConfig.lorebookSettings,
+        promptTemplates: baseConfig.promptTemplates
+      };
+
+    case 'openaicompatible':
+      return {
+        name: 'OpenAI Compatible',
+        provider: 'openaicompatible',
+        apiConfig: {
+          baseURL: (extraConfig.baseURL || 'http://localhost:1234/v1').trim(),
+          apiKey: (extraConfig.apiKey || '').trim(),
+          model: ''
+        },
+        generationSettings: {
+          maxTokens: 4000,
+          maxContextTokens: 8192,
           temperature: 0.7,
           includeDialogueExamples: false,
           stop_sequences: []

--- a/server/src/routes/presets.js
+++ b/server/src/routes/presets.js
@@ -14,6 +14,7 @@ import { AnthropicProvider } from '../services/providers/anthropic-provider.js';
 import { DeepSeekProvider } from '../services/providers/deepseek-provider.js';
 import { KoboldCppProvider } from '../services/providers/koboldcpp-provider.js';
 import { OllamaProvider } from '../services/providers/ollama-provider.js';
+import { OpenAICompatibleProvider } from '../services/providers/openai-compatible-provider.js';
 
 const router = express.Router();
 
@@ -495,6 +496,32 @@ router.get('/ollama/models', asyncHandler(async (req, res) => {
     res.status(502).json({
       error: 'Could not reach Ollama',
       message: `Could not reach Ollama at ${baseURL}. Is it running?`,
+      detail: error.message
+    });
+  }
+}));
+
+// List models advertised by an OpenAI-compatible endpoint. Unlike /openai/models,
+// this does NOT require an apiKey query param — local servers (LM Studio,
+// llama.cpp, vLLM) typically accept any/no Bearer token. Optional token is
+// forwarded if provided.
+router.get('/openaicompatible/models', asyncHandler(async (req, res) => {
+  const baseURL = req.query.baseURL;
+  const apiKey = req.query.apiKey || '';
+
+  if (!baseURL) {
+    return res.status(400).json({ error: 'baseURL query parameter is required' });
+  }
+
+  try {
+    const provider = new OpenAICompatibleProvider({ baseURL, apiKey });
+    const models = await provider.getAvailableModels();
+    res.json({ models });
+  } catch (error) {
+    console.error('Failed to fetch OpenAI-compatible models:', error);
+    res.status(502).json({
+      error: 'Could not reach endpoint',
+      message: `Could not reach OpenAI-compatible endpoint at ${baseURL}. Is it running?`,
       detail: error.message
     });
   }

--- a/server/src/services/default-presets.js
+++ b/server/src/services/default-presets.js
@@ -101,6 +101,40 @@ export const DEFAULT_PROMPT_TEMPLATES = {
 
 export function getDefaultPresets() {
   return {
+    openaicompatible: {
+      name: "OpenAI Compatible",
+      provider: "openaicompatible",
+      apiConfig: {
+        baseURL: "http://localhost:1234/v1",
+        apiKey: "",
+        model: ""
+      },
+      generationSettings: {
+        maxTokens: 4000,
+        maxContextTokens: 8192,
+        temperature: 0.7,
+        includeDialogueExamples: false,
+        top_p: null,
+        frequency_penalty: null,
+        presence_penalty: null,
+        stop_sequences: []
+      },
+      lorebookSettings: {
+        scanDepth: 2000,
+        tokenBudget: 1800,
+        recursionDepth: 3,
+        enableRecursion: true
+      },
+      promptTemplates: {
+        systemPrompt: null,
+        continue: null,
+        character: null,
+        instruction: null,
+        rewriteThirdPerson: null,
+        ideate: null,
+        storyStarter: null
+      }
+    },
     ollama: {
       name: "Ollama",
       provider: "ollama",

--- a/server/src/services/provider-factory.js
+++ b/server/src/services/provider-factory.js
@@ -10,6 +10,7 @@ import { OpenAIProvider } from './providers/openai-provider.js';
 import { AnthropicProvider } from './providers/anthropic-provider.js';
 import { KoboldCppProvider } from './providers/koboldcpp-provider.js';
 import { OllamaProvider } from './providers/ollama-provider.js';
+import { OpenAICompatibleProvider } from './providers/openai-compatible-provider.js';
 
 // Provider registry
 const PROVIDERS = {
@@ -20,6 +21,7 @@ const PROVIDERS = {
   anthropic: AnthropicProvider,
   koboldcpp: KoboldCppProvider,
   ollama: OllamaProvider,
+  openaicompatible: OpenAICompatibleProvider,
 };
 
 /**

--- a/server/src/services/providers/__tests__/openai-compatible-provider.test.js
+++ b/server/src/services/providers/__tests__/openai-compatible-provider.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OpenAICompatibleProvider } from '../openai-compatible-provider.js';
+
+describe('OpenAICompatibleProvider', () => {
+  let provider;
+  let mockFetch;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    provider = new OpenAICompatibleProvider({
+      baseURL: 'http://localhost:1234/v1',
+      model: 'llama-3.2-3b-instruct'
+    });
+  });
+
+  describe('Configuration', () => {
+    it('defaults baseURL to LM Studio convention', () => {
+      const p = new OpenAICompatibleProvider({});
+      expect(p.baseURL).toBe('http://localhost:1234/v1');
+    });
+
+    it('uses a placeholder Bearer token when none provided', () => {
+      const p = new OpenAICompatibleProvider({});
+      expect(p.apiKey).toBe('no-key');
+      expect(p.hasUserToken).toBe(false);
+    });
+
+    it('uses the user-provided Bearer token when present', () => {
+      const p = new OpenAICompatibleProvider({ apiKey: 'real-token' });
+      expect(p.apiKey).toBe('real-token');
+      expect(p.hasUserToken).toBe(true);
+    });
+
+    it('does not treat the placeholder as a user-set token', () => {
+      const p = new OpenAICompatibleProvider({ apiKey: 'no-key' });
+      expect(p.hasUserToken).toBe(false);
+    });
+  });
+
+  describe('Validation', () => {
+    it('passes when baseURL is set, no apiKey required', () => {
+      const p = new OpenAICompatibleProvider({ baseURL: 'http://localhost:1234/v1' });
+      expect(p.validateConfig()).toEqual({ valid: true });
+    });
+
+    it('fails when baseURL is empty', () => {
+      const p = new OpenAICompatibleProvider({ baseURL: '   ' });
+      expect(p.validateConfig().valid).toBe(false);
+    });
+  });
+
+  describe('Capabilities', () => {
+    it('reports streaming true, conservative context default', () => {
+      const caps = provider.getCapabilities();
+      expect(caps.streaming).toBe(true);
+      expect(caps.maxContextWindow).toBe(8192);
+    });
+  });
+
+  describe('Max Tokens Parameter', () => {
+    it('never uses max_completion_tokens (OpenAI-only quirk)', () => {
+      expect(provider.usesMaxCompletionTokens()).toBe(false);
+
+      // Even if the user names a model "gpt-5" the local server still uses max_tokens
+      const p = new OpenAICompatibleProvider({ model: 'gpt-5' });
+      expect(p.usesMaxCompletionTokens()).toBe(false);
+    });
+
+    it('puts max_tokens (not max_completion_tokens) in request body', () => {
+      const body = provider.buildRequestBody([{ role: 'user', content: 'hi' }], {
+        maxTokens: 1234
+      });
+      expect(body.max_tokens).toBe(1234);
+      expect(body.max_completion_tokens).toBeUndefined();
+    });
+  });
+
+  describe('getAvailableModels', () => {
+    it('GETs /models and returns every entry (no chat-name filter)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'llama-3.2-3b-instruct', owned_by: 'lmstudio' },
+            { id: 'Meta-Llama-3.1-8B-Instruct-GGUF', owned_by: 'lmstudio' },
+            { id: 'qwen2.5-coder-7b-instruct', owned_by: 'lmstudio' }
+          ]
+        })
+      });
+
+      const models = await provider.getAvailableModels();
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:1234/v1/models');
+      // No filter applied — non-OpenAI-shaped names all pass through
+      expect(models.map((m) => m.id)).toEqual([
+        'llama-3.2-3b-instruct',
+        'Meta-Llama-3.1-8B-Instruct-GGUF',
+        'qwen2.5-coder-7b-instruct'
+      ]);
+      expect(models[0].description).toBe('owned_by: lmstudio');
+    });
+
+    it('works without a user-provided token (sends placeholder Bearer)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: 'm' }] })
+      });
+      await provider.getAvailableModels();
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer no-key');
+    });
+
+    it('sends the user-provided Bearer when set', async () => {
+      const p = new OpenAICompatibleProvider({
+        baseURL: 'http://localhost:1234/v1',
+        apiKey: 'real-token'
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: 'm' }] })
+      });
+      await p.getAvailableModels();
+      expect(mockFetch.mock.calls[0][1].headers.Authorization).toBe('Bearer real-token');
+    });
+
+    it('returns empty array on fetch failure', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, statusText: 'Not Found' });
+      const models = await provider.getAvailableModels();
+      expect(models).toEqual([]);
+    });
+
+    it('handles a missing data field defensively', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+      const models = await provider.getAvailableModels();
+      expect(models).toEqual([]);
+    });
+  });
+
+  describe('Error Parsing', () => {
+    it('maps 401 to AUTH_ERROR with token-set message when user provided one', () => {
+      const p = new OpenAICompatibleProvider({
+        baseURL: 'http://localhost:1234/v1',
+        apiKey: 'real-token'
+      });
+      const err = p.parseError(new Error('401 Unauthorized'));
+      expect(err.code).toBe('AUTH_ERROR');
+      expect(err.message).toMatch(/check it matches/i);
+    });
+
+    it('maps 401 to AUTH_ERROR with add-token hint when no user token', () => {
+      const err = provider.parseError(new Error('401 Unauthorized'));
+      expect(err.code).toBe('AUTH_ERROR');
+      expect(err.message).toMatch(/add a bearer token/i);
+    });
+
+    it('maps ECONNREFUSED to CONNECTION_ERROR', () => {
+      const err = provider.parseError(new Error('ECONNREFUSED'));
+      expect(err.code).toBe('CONNECTION_ERROR');
+      expect(err.message).toContain('http://localhost:1234/v1');
+    });
+
+    it('falls through to OpenAI error parser for rate-limit etc', () => {
+      const err = provider.parseError(new Error('429 rate limit exceeded'));
+      expect(err.code).toBe('RATE_LIMIT');
+    });
+  });
+
+  describe('Inherited request-shape behavior', () => {
+    it('inherits chat-completions request flow from OpenAIProvider', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'hello from local model' } }]
+        })
+      });
+
+      const result = await provider.generate('SYS', 'USR', { maxTokens: 256 });
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:1234/v1/chat/completions');
+      const body = JSON.parse(opts.body);
+      expect(body.model).toBe('llama-3.2-3b-instruct');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'SYS' },
+        { role: 'user', content: 'USR' }
+      ]);
+      expect(body.max_tokens).toBe(256);
+      expect(result.content).toBe('hello from local model');
+    });
+  });
+});

--- a/server/src/services/providers/openai-compatible-provider.js
+++ b/server/src/services/providers/openai-compatible-provider.js
@@ -1,0 +1,130 @@
+/**
+ * OpenAI-Compatible Provider Implementation
+ *
+ * A thin subclass of OpenAIProvider tailored for local LLM servers that speak
+ * OpenAI's wire format but have different operational characteristics — no
+ * required API key, freely-listable model catalogs, arbitrary model names
+ * (LM Studio, llama.cpp's `--api` mode, vLLM, text-generation-webui's openai
+ * extension, etc.).
+ *
+ * We subclass rather than duplicate because the wire format itself is stable.
+ * If OpenAI's spec ever diverges in a way that breaks compat servers, we can
+ * fork at that point.
+ */
+
+import { OpenAIProvider } from './openai-provider.js';
+
+const DEFAULT_BASE_URL = 'http://localhost:1234/v1';
+// Placeholder Bearer value. LM Studio and friends accept any token (or none),
+// but always sending a header avoids edge cases in middleware that requires
+// the `Authorization` header to be present.
+const PLACEHOLDER_TOKEN = 'no-key';
+
+export class OpenAICompatibleProvider extends OpenAIProvider {
+  constructor(config) {
+    // Hand the parent a populated apiKey so all its Bearer-Authorization code
+    // paths "just work" without overriding every request method. The user-set
+    // token (if any) goes in apiKey; otherwise the placeholder.
+    const compatConfig = {
+      ...config,
+      baseURL: config.baseURL || DEFAULT_BASE_URL,
+      apiKey: config.apiKey || PLACEHOLDER_TOKEN,
+      model: config.model || ''
+    };
+
+    super(compatConfig);
+
+    // Track whether the user actually provided a token, distinct from the
+    // placeholder we may have substituted in.
+    this.hasUserToken = !!(config.apiKey && config.apiKey !== PLACEHOLDER_TOKEN);
+  }
+
+  getCapabilities() {
+    return {
+      streaming: true,
+      reasoning: false,
+      visionAPI: false,
+      // Conservative default — most local models are 4k–32k. Users set the
+      // real value per preset.
+      maxContextWindow: 8192
+    };
+  }
+
+  /**
+   * Compat endpoints don't require an API key — only a reachable base URL.
+   * A token is accepted but optional.
+   */
+  validateConfig() {
+    if (!this.baseURL || this.baseURL.trim() === '') {
+      return { valid: false, error: 'Base URL is required' };
+    }
+    return { valid: true };
+  }
+
+  /**
+   * Local servers don't use OpenAI's max_completion_tokens convention — that's
+   * specific to GPT-5/o1/o3. Always use plain max_tokens.
+   */
+  usesMaxCompletionTokens() {
+    return false;
+  }
+
+  /**
+   * Return every model the endpoint advertises. The parent class filters for
+   * OpenAI's chat-model name patterns (gpt-4, o1, …), which would drop
+   * literally everything served by LM Studio, vLLM, etc. — their model names
+   * are arbitrary (`llama-3.2-3b-instruct`, `Meta-Llama-3.1-8B-Instruct-GGUF`).
+   */
+  async getAvailableModels() {
+    try {
+      const response = await fetch(`${this.baseURL}/models`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch models: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      const models = Array.isArray(data?.data) ? data.data : [];
+
+      return models.map((model) => ({
+        id: model.id,
+        name: model.id,
+        description: model.owned_by ? `owned_by: ${model.owned_by}` : '',
+        contextLength: 0, // not exposed by the OpenAI /models shape
+        created: model.created,
+        ownedBy: model.owned_by
+      }));
+    } catch (error) {
+      console.error('Failed to fetch OpenAI-compatible models:', error);
+      return [];
+    }
+  }
+
+  parseError(error) {
+    const msg = error.message || '';
+    if (msg.includes('401') || msg.toLowerCase().includes('unauthorized')) {
+      return {
+        code: 'AUTH_ERROR',
+        message: this.hasUserToken
+          ? 'Endpoint rejected the Bearer token. Check it matches what the server expects.'
+          : 'Endpoint requires authentication. Add a Bearer token in preset settings.',
+        original: error
+      };
+    }
+    if (msg.includes('ECONNREFUSED') || msg.includes('fetch failed') || error.cause?.code === 'ECONNREFUSED') {
+      return {
+        code: 'CONNECTION_ERROR',
+        message: `Could not reach endpoint at ${this.baseURL}`,
+        original: error
+      };
+    }
+    // Fall through to the OpenAIProvider's parsing for rate-limit/quota cases,
+    // even though they rarely apply to local servers — harmless if they don't.
+    return super.parseError(error);
+  }
+}

--- a/vue_client/src/components/PresetEditorModal.vue
+++ b/vue_client/src/components/PresetEditorModal.vue
@@ -177,8 +177,8 @@ onMounted(async () => {
 
 const canSave = computed(() => {
   const apiConfig = formData.value.apiConfig || {}
-  // KoboldCpp and Ollama authenticate with a URL (+ optional password), not an API key
-  if (['koboldcpp', 'ollama'].includes(formData.value.provider)) {
+  // Local providers authenticate with a URL (+ optional token), not a required API key
+  if (['koboldcpp', 'ollama', 'openaicompatible'].includes(formData.value.provider)) {
     return formData.value.name.trim() && (apiConfig.baseURL || '').trim() !== ''
   }
   // AI Horde uses "0000000000" as default anonymous key, so it's always valid

--- a/vue_client/src/components/StoryPresetModal.vue
+++ b/vue_client/src/components/StoryPresetModal.vue
@@ -309,6 +309,11 @@ function getProviderDisplayName(provider) {
   color: #3949ab;
 }
 
+.provider-openaicompatible {
+  background-color: #f1f8e9;
+  color: #558b2f;
+}
+
 .action-buttons {
   padding-top: 0.5rem;
   border-top: 1px solid var(--border-color);

--- a/vue_client/src/components/providers/OpenAICompatibleConfig.vue
+++ b/vue_client/src/components/providers/OpenAICompatibleConfig.vue
@@ -1,0 +1,180 @@
+<template>
+  <BaseProviderConfig
+    :config="config"
+    @update:config="$emit('update:config', $event)"
+    :show-max-context="true"
+    :context-range="{ min: 1024, max: 131072 }"
+    :context-help-text="`Context window in tokens. Set this to whatever the loaded model can actually handle.`"
+    provider="openaicompatible"
+    :model="localApiConfig.model || ''"
+  >
+    <template #api-config>
+      <div class="form-group">
+        <label for="oaiCompatBaseURL">Base URL</label>
+        <input
+          id="oaiCompatBaseURL"
+          v-model="localApiConfig.baseURL"
+          type="text"
+          class="text-input"
+          placeholder="http://localhost:1234/v1"
+        />
+        <small class="help-text">
+          OpenAI-shaped endpoint, e.g. LM Studio (port 1234), llama.cpp <code>--api</code>
+          (port 8080), or vLLM. The URL should end in <code>/v1</code> so request paths like
+          <code>/chat/completions</code> resolve correctly.
+        </small>
+      </div>
+
+      <div class="form-group">
+        <label for="oaiCompatApiKey">Bearer Token <span class="optional">(optional)</span></label>
+        <input
+          id="oaiCompatApiKey"
+          v-model="localApiConfig.apiKey"
+          type="password"
+          class="text-input"
+          placeholder="Leave empty if your endpoint doesn't require auth"
+        />
+        <small class="help-text">
+          Only needed if you've put auth in front of the endpoint. Most local servers accept
+          any token (or none).
+        </small>
+      </div>
+
+      <ModelSelector
+        :models="availableModels"
+        :selected-model="localApiConfig.model"
+        :loading="loadingModels"
+        :error="modelsError"
+        :can-fetch="!!localApiConfig.baseURL"
+        :requires-api-key="false"
+        description="Pick which model the endpoint should use. Load a model in your server first (LM Studio, llama.cpp, etc.) and click Fetch again to refresh."
+        empty-state-text="Enter your endpoint URL above and click Fetch Available Models."
+        @fetch="fetchModels"
+        @select="selectModel"
+      />
+    </template>
+  </BaseProviderConfig>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import BaseProviderConfig from './shared/BaseProviderConfig.vue'
+import ModelSelector from './shared/ModelSelector.vue'
+import { presetsAPI } from '../../services/api'
+import { useToast } from '../../composables/useToast'
+
+const props = defineProps({
+  config: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:config'])
+
+const toast = useToast()
+
+const availableModels = ref([])
+const loadingModels = ref(false)
+const modelsError = ref(null)
+
+const localApiConfig = computed({
+  get() {
+    return props.config.apiConfig || {}
+  },
+  set(value) {
+    emit('update:config', { ...props.config, apiConfig: value })
+  }
+})
+
+async function fetchModels(silent = false) {
+  if (!localApiConfig.value.baseURL) {
+    modelsError.value = 'Base URL is required to fetch models'
+    return
+  }
+
+  try {
+    loadingModels.value = true
+    modelsError.value = null
+    const response = await presetsAPI.getOpenAICompatibleModels(
+      localApiConfig.value.baseURL,
+      localApiConfig.value.apiKey
+    )
+    availableModels.value = response.models || []
+    if (availableModels.value.length === 0) {
+      modelsError.value = 'Endpoint returned no models. Load one in your server first.'
+    } else if (!silent) {
+      toast.success(`Loaded ${availableModels.value.length} model${availableModels.value.length !== 1 ? 's' : ''}`)
+    }
+  } catch (error) {
+    modelsError.value = error.message || 'Failed to reach endpoint'
+    console.error('Failed to fetch OpenAI-compatible models:', error)
+  } finally {
+    loadingModels.value = false
+  }
+}
+
+function selectModel(model) {
+  localApiConfig.value = {
+    ...localApiConfig.value,
+    model: model.id
+  }
+  toast.success(`Selected model: ${model.name || model.id}`)
+}
+
+onMounted(() => {
+  if (localApiConfig.value.baseURL && localApiConfig.value.model) {
+    fetchModels(true)
+  }
+})
+</script>
+
+<style scoped>
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.optional {
+  font-weight: 400;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.text-input {
+  width: 100%;
+  padding: 0.6rem;
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.help-text {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.help-text code {
+  background-color: var(--bg-tertiary);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+</style>

--- a/vue_client/src/components/providers/index.js
+++ b/vue_client/src/components/providers/index.js
@@ -10,6 +10,7 @@ import AnthropicConfig from './AnthropicConfig.vue'
 import OpenRouterConfig from './OpenRouterConfig.vue'
 import KoboldCppConfig from './KoboldCppConfig.vue'
 import OllamaConfig from './OllamaConfig.vue'
+import OpenAICompatibleConfig from './OpenAICompatibleConfig.vue'
 
 // Re-export consolidated provider metadata from config
 export { PROVIDERS } from '../../config/providerDefaults'
@@ -21,7 +22,8 @@ export const PROVIDER_COMPONENTS = {
   anthropic: AnthropicConfig,
   openrouter: OpenRouterConfig,
   koboldcpp: KoboldCppConfig,
-  ollama: OllamaConfig
+  ollama: OllamaConfig,
+  openaicompatible: OpenAICompatibleConfig
 }
 
 /**

--- a/vue_client/src/components/providers/shared/AdvancedSamplingSettings.vue
+++ b/vue_client/src/components/providers/shared/AdvancedSamplingSettings.vue
@@ -326,7 +326,7 @@ const emit = defineEmits(['update:modelValue'])
 
 // Provider capability checks
 const supportsTopP = computed(() => {
-  return ['anthropic', 'openai', 'deepseek', 'openrouter', 'aihorde', 'koboldcpp', 'ollama'].includes(props.provider)
+  return ['anthropic', 'openai', 'deepseek', 'openrouter', 'aihorde', 'koboldcpp', 'ollama', 'openaicompatible'].includes(props.provider)
 })
 
 const supportsTopK = computed(() => {
@@ -338,7 +338,7 @@ const supportsFrequencyPenalty = computed(() => {
   if (props.provider === 'deepseek' && props.modelValue?.thinking) {
     return false
   }
-  return ['openai', 'deepseek', 'openrouter'].includes(props.provider)
+  return ['openai', 'deepseek', 'openrouter', 'openaicompatible'].includes(props.provider)
 })
 
 const supportsPresencePenalty = computed(() => {
@@ -346,7 +346,7 @@ const supportsPresencePenalty = computed(() => {
   if (props.provider === 'deepseek' && props.modelValue?.thinking) {
     return false
   }
-  return ['openai', 'deepseek', 'openrouter'].includes(props.provider)
+  return ['openai', 'deepseek', 'openrouter', 'openaicompatible'].includes(props.provider)
 })
 
 const localSettings = computed({

--- a/vue_client/src/config/providerDefaults.js
+++ b/vue_client/src/config/providerDefaults.js
@@ -182,6 +182,49 @@ export const PROVIDERS = {
     }
   },
 
+  openaicompatible: {
+    // Display information
+    name: 'OpenAI Compatible',
+    description: 'Local server with an OpenAI-shaped API (LM Studio, llama.cpp, vLLM)',
+    icon: 'fa-plug',
+    // Capabilities
+    supportsReasoning: false,
+    supportsStreaming: true,
+    requiresModelSelection: true,
+    // Default configuration
+    defaults: {
+      provider: 'openaicompatible',
+      apiConfig: {
+        baseURL: 'http://localhost:1234/v1',
+        apiKey: '',
+        model: ''
+      },
+      generationSettings: {
+        maxTokens: 4000,
+        temperature: 0.7,
+        maxContextTokens: 8192,
+        includeDialogueExamples: false,
+        // Standard OpenAI-shape samplers (null = use server defaults)
+        top_p: null,
+        frequency_penalty: null,
+        presence_penalty: null
+      },
+      lorebookSettings: {
+        scanDepth: 2000,
+        tokenBudget: 1800,
+        recursionDepth: 3,
+        enableRecursion: true
+      },
+      promptTemplates: {
+        systemPrompt: null,
+        continue: null,
+        character: null,
+        instruction: null,
+        rewriteThirdPerson: null
+      }
+    }
+  },
+
   ollama: {
     // Display information
     name: 'Ollama',

--- a/vue_client/src/services/api.js
+++ b/vue_client/src/services/api.js
@@ -675,6 +675,13 @@ export const presetsAPI = {
     return request(`/presets/ollama/show?${params.toString()}`)
   },
 
+  // OpenAI-Compatible (LM Studio / llama.cpp / vLLM) specific methods
+  getOpenAICompatibleModels(baseURL, apiKey = '') {
+    const params = new URLSearchParams({ baseURL })
+    if (apiKey) params.set('apiKey', apiKey)
+    return request(`/presets/openaicompatible/models?${params.toString()}`)
+  },
+
   // Get default prompt templates (single source of truth from server)
   getDefaultTemplates() {
     return request('/presets/defaults/templates')

--- a/vue_client/src/views/OnboardingWizard.vue
+++ b/vue_client/src/views/OnboardingWizard.vue
@@ -109,7 +109,7 @@
           </div>
         </div>
 
-        <div v-if="selectedProvider && !['aihorde', 'koboldcpp', 'ollama'].includes(selectedProvider)" class="form-group">
+        <div v-if="selectedProvider && !['aihorde', 'koboldcpp', 'ollama', 'openaicompatible'].includes(selectedProvider)" class="form-group">
           <label :for="'apiKey-' + selectedProvider">
             {{ getProviderName(selectedProvider) }} API Key
           </label>
@@ -189,6 +189,32 @@
               v-model="ollamaPassword"
               type="password"
               placeholder="Only if you've put Ollama behind a reverse proxy with auth"
+            />
+          </div>
+        </template>
+
+        <template v-if="selectedProvider === 'openaicompatible'">
+          <div class="form-group">
+            <label for="oaicompat-baseURL">Endpoint URL</label>
+            <input
+              id="oaicompat-baseURL"
+              v-model="oaiCompatBaseURL"
+              type="text"
+              placeholder="http://localhost:1234/v1"
+            />
+            <p class="help-text">
+              Any server speaking OpenAI's API shape: LM Studio (port 1234), llama.cpp
+              <code>--api</code> mode (port 8080), vLLM, etc. The URL should end in
+              <code>/v1</code>. You'll pick a model in preset settings after onboarding.
+            </p>
+          </div>
+          <div class="form-group">
+            <label for="oaicompat-apiKey">Bearer Token <span class="optional-label">(optional)</span></label>
+            <input
+              id="oaicompat-apiKey"
+              v-model="oaiCompatApiKey"
+              type="password"
+              placeholder="Only if your endpoint requires auth"
             />
           </div>
         </template>
@@ -332,6 +358,8 @@ const koboldBaseURL = ref('http://localhost:5001/api')
 const koboldPassword = ref('')
 const ollamaBaseURL = ref('http://localhost:11434')
 const ollamaPassword = ref('')
+const oaiCompatBaseURL = ref('http://localhost:1234/v1')
+const oaiCompatApiKey = ref('')
 
 const providers = [
   {
@@ -369,6 +397,11 @@ const providers = [
     id: 'ollama',
     name: 'Ollama',
     description: 'Connect to a local Ollama endpoint you\'re already running.'
+  },
+  {
+    id: 'openaicompatible',
+    name: 'OpenAI Compatible',
+    description: 'Any local server that speaks OpenAI\'s API (LM Studio, llama.cpp, vLLM).'
   }
 ]
 
@@ -383,6 +416,7 @@ const canProceedFromProvider = computed(() => {
   if (selectedProvider.value === 'aihorde') return true
   if (selectedProvider.value === 'koboldcpp') return koboldBaseURL.value.trim().length > 0
   if (selectedProvider.value === 'ollama') return ollamaBaseURL.value.trim().length > 0
+  if (selectedProvider.value === 'openaicompatible') return oaiCompatBaseURL.value.trim().length > 0
   return apiKey.value.trim().length > 0
 })
 
@@ -467,6 +501,11 @@ async function createPreset() {
       toast.error('Please enter a URL for your Ollama endpoint')
       return
     }
+  } else if (selectedProvider.value === 'openaicompatible') {
+    if (!oaiCompatBaseURL.value.trim()) {
+      toast.error('Please enter a URL for your OpenAI-compatible endpoint')
+      return
+    }
   } else if (selectedProvider.value !== 'aihorde' && !apiKey.value.trim()) {
     toast.error('Please enter your API key')
     return
@@ -481,6 +520,8 @@ async function createPreset() {
       extraConfig = { baseURL: koboldBaseURL.value.trim(), password: koboldPassword.value.trim() }
     } else if (selectedProvider.value === 'ollama') {
       extraConfig = { baseURL: ollamaBaseURL.value.trim(), password: ollamaPassword.value.trim() }
+    } else if (selectedProvider.value === 'openaicompatible') {
+      extraConfig = { baseURL: oaiCompatBaseURL.value.trim(), apiKey: oaiCompatApiKey.value.trim() }
     }
     const result = await onboardingAPI.createPreset(
       selectedProvider.value,

--- a/vue_client/src/views/__tests__/OnboardingWizard.test.js
+++ b/vue_client/src/views/__tests__/OnboardingWizard.test.js
@@ -184,7 +184,7 @@ describe('OnboardingWizard', () => {
 
     it('should show all provider options', () => {
       const providers = wrapper.findAll('.provider-option')
-      expect(providers).toHaveLength(7)
+      expect(providers).toHaveLength(8)
     })
 
     it('should have DeepSeek selected by default', () => {


### PR DESCRIPTION
## Summary
- Adds a dedicated **OpenAI Compatible** provider tailored for local servers that speak the OpenAI wire format — LM Studio, llama.cpp's \`--api\` mode, vLLM, text-generation-webui's openai extension, etc. Previously these were supported by typing a custom \`baseURL\` into the OpenAI preset's advanced settings, but that path had the obtuse-UX problem that fetching the model list still required an API key even though local servers don't issue one.
- Implemented as a thin subclass of \`OpenAIProvider\` so the wire shape stays in sync if/when OpenAI evolves it. Overrides: \`validateConfig\` (requires baseURL, not apiKey), \`getAvailableModels\` (skips the gpt-\*/o-series name filter that would drop every LM Studio model), \`usesMaxCompletionTokens\` (always false), and \`parseError\` (clearer messages distinguishing token-rejected from token-not-set).
- New \`GET /presets/openaicompatible/models\` route — unlike the existing \`/openai/models\`, this does **not** require an \`apiKey\` query param. baseURL is all that's needed. Optional Bearer token is forwarded if provided.
- Onboarding wizard has it as an 8th option with URL + optional Bearer form. Default URL \`http://localhost:1234/v1\` (LM Studio's convention).
- Preset chip in \`StoryPresetModal\` gets a light-green style to fit the existing material palette.

## Design note
The Bearer header is always sent (\`Authorization: Bearer no-key\` when the user hasn't set a token). Most local servers accept any value or none, but middleware (nginx, traefik) sometimes requires the header to be present at all — sending a placeholder is a safer default than omitting it. If the user does set a token, that's what goes on the wire.

## Test plan
- [x] Server unit tests pass (817 total, 19 new in \`openai-compatible-provider.test.js\`)
- [x] Client tests pass (191 total)
- [x] Client builds clean
- [ ] Fetch models against a running LM Studio instance without setting a Bearer token — model list populates
- [ ] Generate a continuation, confirm tokens stream incrementally
- [ ] Cancel mid-generation disconnects cleanly (no abort endpoint in OpenAI shape — disconnect is the abort)
- [ ] Set a Bearer token in the preset, confirm it's sent on the wire (verify in server logs)
- [ ] Pick a model with a non-OpenAI-shaped name (e.g. \`Meta-Llama-3.1-8B-Instruct-GGUF\`) — should appear in the picker rather than being filtered out
- [ ] Regression: existing OpenAI preset (with real \`api.openai.com\` apiKey) still fetches models and generates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)