### PR TITLE
Image Preservation, Preview Mode, and UX Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,5 @@ server/public/
 # macOS
 .DS_Store
 **/.DS_Store
+
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ writers-guild/
 - **Client**: Vue 3 with Vue Router and Vite
 - **Hot Reload**: Both server and client support hot-reload in dev mode
 
+## Android Build
+
+- To build natively in Android you need `node-addon-api` and `node-gyp`
+
+
 ## API
 
 The server runs on port 8000 and provides:

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.9",
+    "node-addon-api": "^8.8.0",
+    "node-gyp": "^12.4.0",
     "supertest": "^7.1.4",
     "vitest": "^4.0.9"
   }

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.9",
     "node-addon-api": "^8.8.0",
-    "node-gyp": "^12.4.0",
+    "node-gyp": "^12.4.0", 
     "supertest": "^7.1.4",
     "vitest": "^4.0.9"
   }

--- a/server/src/routes/characters.js
+++ b/server/src/routes/characters.js
@@ -42,6 +42,49 @@ router.use((req, res, next) => {
   next();
 });
 
+/**
+ * Extract embedded lorebook from character data and save it to storage.
+ * Modifies cardData.data.extensions.ursceal_lorebook_id in place.
+ * @returns {{ embeddedLorebook: object|null, lorebookId: string|null }}
+ */
+async function extractAndSaveEmbeddedLorebook(storageInstance, cardData) {
+  let embeddedLorebook = null;
+  let lorebookId = null;
+
+  if (cardData.data?.character_book && cardData.data.character_book.entries && cardData.data.character_book.entries.length > 0) {
+    try {
+      // Parse embedded lorebook
+      const lorebookData = LorebookParser.parseEmbeddedLorebook(cardData.data.character_book);
+
+      // Give it a name based on the character
+      lorebookData.name = `${cardData.data.name}'s Lorebook`;
+      lorebookData.description = lorebookData.description || `Lorebook for ${cardData.data.name}`;
+
+      // Save to global lorebook library
+      lorebookId = uuidv4();
+      await storageInstance.saveLorebook(lorebookId, lorebookData);
+
+      embeddedLorebook = {
+        id: lorebookId,
+        name: lorebookData.name,
+        entryCount: lorebookData.entries.length
+      };
+
+      console.log(`Extracted embedded lorebook from ${cardData.data.name}: ${lorebookData.entries.length} entries`);
+    } catch (error) {
+      console.error('Failed to parse embedded lorebook:', error);
+    }
+  }
+
+  // Add lorebook association to character data
+  if (!cardData.data.extensions) {
+    cardData.data.extensions = {};
+  }
+  cardData.data.extensions.ursceal_lorebook_id = lorebookId;
+
+  return { embeddedLorebook, lorebookId };
+}
+
 // ==================== Global Character Library ====================
 
 // List all characters in global library
@@ -122,41 +165,10 @@ router.post('/import', upload.single('character'), asyncHandler(async (req, res)
   try {
     const cardData = await CharacterParser.parseCard(req.file.buffer);
 
-    // Check for embedded lorebook (V2 character cards)
-    let embeddedLorebook = null;
-    let lorebookId = null;
-    if (cardData.data?.character_book && cardData.data.character_book.entries && cardData.data.character_book.entries.length > 0) {
-      try {
-        // Parse embedded lorebook
-        const lorebookData = LorebookParser.parseEmbeddedLorebook(cardData.data.character_book);
+      // Extract embedded lorebook if present
+      const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
 
-        // Give it a name based on the character
-        lorebookData.name = `${cardData.data.name}'s Lorebook`;
-        lorebookData.description = lorebookData.description || `Lorebook for ${cardData.data.name}`;
-
-        // Save to global lorebook library
-        lorebookId = uuidv4();
-        await storage.saveLorebook(lorebookId, lorebookData);
-
-        embeddedLorebook = {
-          id: lorebookId,
-          name: lorebookData.name,
-          entryCount: lorebookData.entries.length
-        };
-
-        console.log(`Extracted embedded lorebook from ${cardData.data.name}: ${lorebookData.entries.length} entries`);
-      } catch (error) {
-        console.error('Failed to parse embedded lorebook:', error);
-      }
-    }
-
-    // Add lorebook association to character data
-    if (!cardData.data.extensions) {
-      cardData.data.extensions = {};
-    }
-    cardData.data.extensions.ursceal_lorebook_id = lorebookId;
-
-    // Save character data as JSON and image separately
+      // Save character data as JSON and image separately
     await storage.saveCharacter(characterId, cardData, req.file.buffer);
 
     res.status(201).json({
@@ -286,76 +298,38 @@ router.post('/import-json', jsonUpload.single('character'), asyncHandler(async (
     throw new AppError('No character file provided', 400);
   }
 
+  // Parse JSON from buffer
+  const jsonString = req.file.buffer.toString('utf8');
+  let cardData;
   try {
-    // Parse JSON from buffer
-    const jsonString = req.file.buffer.toString('utf8');
-    let cardData;
-    try {
-      cardData = JSON.parse(jsonString);
-    } catch (e) {
-      throw new AppError('Invalid JSON file: ' + e.message, 400);
-    }
-
-    // Support both V2 format (with data wrapper) and flat format
-    if (!cardData.data) {
-      // Try treating the whole JSON as the data field
-      cardData = {
-        spec: 'chara_card_v2',
-        spec_version: '2.0',
-        data: cardData
-      };
-    }
-
-    if (!cardData.data || !cardData.data.name) {
-      throw new AppError('Invalid character card: missing name or data field', 400);
-    }
-
-    const characterId = uuidv4();
-
-    // Check for embedded lorebook
-    let embeddedLorebook = null;
-    let lorebookId = null;
-    if (cardData.data?.character_book && cardData.data.character_book.entries && cardData.data.character_book.entries.length > 0) {
-      try {
-        const lorebookData = LorebookParser.parseEmbeddedLorebook(cardData.data.character_book);
-        lorebookData.name = `${cardData.data.name}'s Lorebook`;
-        lorebookData.description = lorebookData.description || `Lorebook for ${cardData.data.name}`;
-
-        lorebookId = uuidv4();
-        await storage.saveLorebook(lorebookId, lorebookData);
-
-        embeddedLorebook = {
-          id: lorebookId,
-          name: lorebookData.name,
-          entryCount: lorebookData.entries.length
-        };
-
-        console.log(`Extracted embedded lorebook from ${cardData.data.name}: ${lorebookData.entries.length} entries`);
-      } catch (error) {
-        console.error('Failed to parse embedded lorebook:', error);
-      }
-    }
-
-    // Add lorebook association to character data
-    if (!cardData.data.extensions) {
-      cardData.data.extensions = {};
-    }
-    cardData.data.extensions.ursceal_lorebook_id = lorebookId;
-
-    // Save character data (no image for JSON import)
-    await storage.saveCharacter(characterId, cardData, null);
-
-    res.status(201).json({
-      id: characterId,
-      name: cardData.data.name,
-      description: cardData.data.description || '',
-      imageUrl: null,
-      firstMessage: cardData.data.first_mes || '',
-      embeddedLorebook: embeddedLorebook
-    });
-  } catch (error) {
-    throw new AppError(`Failed to import character: ${error.message}`, 400);
+    cardData = JSON.parse(jsonString);
+  } catch (e) {
+    throw new AppError('Invalid JSON file: ' + e.message, 400);
   }
+
+  // Normalize card data (handles V2 vs flat format)
+  cardData = CharacterParser.normalizeCardData(cardData);
+
+  if (!cardData.data || !cardData.data.name) {
+    throw new AppError('Invalid character card: missing name or data field', 400);
+  }
+
+  const characterId = uuidv4();
+
+  // Extract embedded lorebook if present
+  const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
+
+  // Save character data (no image for JSON import)
+  await storage.saveCharacter(characterId, cardData, null);
+
+  res.status(201).json({
+    id: characterId,
+    name: cardData.data.name,
+    description: cardData.data.description || '',
+    imageUrl: null,
+    firstMessage: cardData.data.first_mes || '',
+    embeddedLorebook: embeddedLorebook
+  });
 }));
 
 // Import character from URL (CHUB, etc.)
@@ -377,35 +351,8 @@ router.post('/import-url', asyncHandler(async (req, res) => {
 
     const characterId = uuidv4();
 
-    // Check for embedded lorebook
-    let embeddedLorebook = null;
-    let lorebookId = null;
-    if (characterData.data?.character_book && characterData.data.character_book.entries && characterData.data.character_book.entries.length > 0) {
-      try {
-        const lorebookData = LorebookParser.parseEmbeddedLorebook(characterData.data.character_book);
-        lorebookData.name = `${characterData.data.name}'s Lorebook`;
-        lorebookData.description = lorebookData.description || `Lorebook for ${characterData.data.name}`;
-
-        lorebookId = uuidv4();
-        await storage.saveLorebook(lorebookId, lorebookData);
-
-        embeddedLorebook = {
-          id: lorebookId,
-          name: lorebookData.name,
-          entryCount: lorebookData.entries.length
-        };
-
-        console.log(`Extracted embedded lorebook from ${characterData.data.name}: ${lorebookData.entries.length} entries`);
-      } catch (error) {
-        console.error('Failed to parse embedded lorebook:', error);
-      }
-    }
-
-    // Add lorebook association to character data
-    if (!characterData.data.extensions) {
-      characterData.data.extensions = {};
-    }
-    characterData.data.extensions.ursceal_lorebook_id = lorebookId;
+    // Extract embedded lorebook if present
+    const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, characterData);
 
     // Save character with image
     await storage.saveCharacter(characterId, characterData, imageBuffer);

--- a/server/src/routes/characters.js
+++ b/server/src/routes/characters.js
@@ -20,14 +20,17 @@ const upload = multer({
     fileSize: 10 * 1024 * 1024, // 10MB limit
   },
   fileFilter: (req, file, cb) => {
-    const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg'];
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/avif'];
     if (!allowedTypes.includes(file.mimetype)) {
-      cb(new AppError('Only PNG and JPEG images are allowed', 400));
+      cb(new AppError('Only PNG, JPEG, WebP, and AVIF images are allowed', 400));
     } else {
       cb(null, true);
     }
   },
 });
+
+// Configure multer for JSON uploads (import-json route)
+const jsonUpload = multer({ storage: multer.memoryStorage() });
 
 // Initialize storage service
 let storage;
@@ -273,6 +276,86 @@ router.post('/create', upload.single('image'), asyncHandler(async (req, res) => 
     imageUrl: hasImage ? `/api/characters/${characterId}/image` : null,
     firstMessage: characterData.data.first_mes,
   });
+}));
+
+/**
+ * Import character from JSON file (standalone .json character card)
+ */
+router.post('/import-json', jsonUpload.single('character'), asyncHandler(async (req, res) => {
+  if (!req.file) {
+    throw new AppError('No character file provided', 400);
+  }
+
+  try {
+    // Parse JSON from buffer
+    const jsonString = req.file.buffer.toString('utf8');
+    let cardData;
+    try {
+      cardData = JSON.parse(jsonString);
+    } catch (e) {
+      throw new AppError('Invalid JSON file: ' + e.message, 400);
+    }
+
+    // Support both V2 format (with data wrapper) and flat format
+    if (!cardData.data) {
+      // Try treating the whole JSON as the data field
+      cardData = {
+        spec: 'chara_card_v2',
+        spec_version: '2.0',
+        data: cardData
+      };
+    }
+
+    if (!cardData.data || !cardData.data.name) {
+      throw new AppError('Invalid character card: missing name or data field', 400);
+    }
+
+    const characterId = uuidv4();
+
+    // Check for embedded lorebook
+    let embeddedLorebook = null;
+    let lorebookId = null;
+    if (cardData.data?.character_book && cardData.data.character_book.entries && cardData.data.character_book.entries.length > 0) {
+      try {
+        const lorebookData = LorebookParser.parseEmbeddedLorebook(cardData.data.character_book);
+        lorebookData.name = `${cardData.data.name}'s Lorebook`;
+        lorebookData.description = lorebookData.description || `Lorebook for ${cardData.data.name}`;
+
+        lorebookId = uuidv4();
+        await storage.saveLorebook(lorebookId, lorebookData);
+
+        embeddedLorebook = {
+          id: lorebookId,
+          name: lorebookData.name,
+          entryCount: lorebookData.entries.length
+        };
+
+        console.log(`Extracted embedded lorebook from ${cardData.data.name}: ${lorebookData.entries.length} entries`);
+      } catch (error) {
+        console.error('Failed to parse embedded lorebook:', error);
+      }
+    }
+
+    // Add lorebook association to character data
+    if (!cardData.data.extensions) {
+      cardData.data.extensions = {};
+    }
+    cardData.data.extensions.ursceal_lorebook_id = lorebookId;
+
+    // Save character data (no image for JSON import)
+    await storage.saveCharacter(characterId, cardData, null);
+
+    res.status(201).json({
+      id: characterId,
+      name: cardData.data.name,
+      description: cardData.data.description || '',
+      imageUrl: null,
+      firstMessage: cardData.data.first_mes || '',
+      embeddedLorebook: embeddedLorebook
+    });
+  } catch (error) {
+    throw new AppError(`Failed to import character: ${error.message}`, 400);
+  }
 }));
 
 // Import character from URL (CHUB, etc.)

--- a/server/src/routes/stories.js
+++ b/server/src/routes/stories.js
@@ -674,16 +674,8 @@ function setupSSE(res) {
 async function streamGeneration(res, provider, preset, context, generationType, params, abortSignal = null) {
   console.log(`[streamGeneration] Starting ${generationType}, signal present: ${!!abortSignal}, aborted: ${abortSignal?.aborted}`);
 
-  // --- Image preservation: extract embedded images before sending to the LLM ---
-  const imagePreserver = new ImagePreserver();
-  if (context.story?.content) {
-    const preserved = imagePreserver.preserve(context.story.content);
-    if (preserved !== context.story.content) {
-      console.log(`[ImagePreserver] Extracted ${imagePreserver.saved.length} image(s) from story content`);
-      // Temporarily replace story content with placeholders for the LLM
-      context.story.content = preserved;
-    }
-  }
+  // --- Image preservation: will be done after truncation inside buildPrompts ---
+  const imagePreserver = generationType === 'rewriteThirdPerson' ? new ImagePreserver() : null;
 
   // Build both system and user prompts with proper context management
   const prompts = await provider.buildPrompts(
@@ -698,25 +690,19 @@ async function streamGeneration(res, provider, preset, context, generationType, 
     {
       characterName: params.characterName,
       customInstruction: params.customInstruction,
-      templateText: preset.promptTemplates?.[generationType]
+      templateText: preset.promptTemplates?.[generationType],
+      imagePreserver
     },
     preset
   );
 
   const { system: systemPrompt, user: userPrompt } = prompts;
 
-  // For rewriteThirdPerson: append image preservation note so the prompt-aware placeholders survive
-  let effectiveUserPrompt = userPrompt;
-  if (generationType === 'rewriteThirdPerson' && imagePreserver.saved.length > 0) {
-    effectiveUserPrompt = userPrompt + '\n\nIMPORTANT: Preserve any markers like [WG_IMAGE_0], [WG_IMAGE_1] etc. (image references) exactly as they appear in the text above. Do not remove or modify them.';
-    console.log(`[ImagePreserver] Appended image-preservation note for ${generationType}`);
-  }
-
   // Send prompts for debugging
   res.write(`data: ${JSON.stringify({
     prompts: {
       system: systemPrompt,
-      user: effectiveUserPrompt
+      user: userPrompt
     }
   })}\n\n`);
 
@@ -728,7 +714,7 @@ async function streamGeneration(res, provider, preset, context, generationType, 
   if (capabilities.streaming) {
     console.log(`[streamGeneration] Using streaming provider, signal: ${!!abortSignal}`);
     // Start streaming generation
-    const { stream, metadata } = await provider.generateStreaming(systemPrompt, effectiveUserPrompt, {
+    const { stream, metadata } = await provider.generateStreaming(systemPrompt, userPrompt, {
       // Pass all advanced sampling parameters
       ...preset.generationSettings,
       maxContextLength: preset.generationSettings.maxContextTokens,
@@ -755,17 +741,13 @@ async function streamGeneration(res, provider, preset, context, generationType, 
           finished: chunk.finished || false,
         };
 
-        if (chunk.finished && imagePreserver.saved.length > 0) {
+        if (chunk.finished && imagePreserver) {
           // Restore images directly into the finished chunk
-          const { text: restoredContent, missing } = imagePreserver.restore(fullContent);
-          data.finalContent = restoredContent
-            ? missing.length > 0
-              ? restoredContent + '\n\n' + missing.map(m => m.original).join('\n')
-              : restoredContent
-            : missing.map(m => m.original).join('\n');
-          data.imagesRestored = true;
-          data.imagesPreserved = imagePreserver.saved.length;
-          data.imagesMissing = missing.length;
+          const { finalContent, imagesRestored, imagesPreserved, imagesMissing } = imagePreserver.restoreImages(fullContent);
+          data.finalContent = finalContent;
+          data.imagesRestored = imagesRestored;
+          data.imagesPreserved = imagesPreserved;
+          data.imagesMissing = imagesMissing;
         }
 
         res.write(`data: ${JSON.stringify(data)}\n\n`);
@@ -779,7 +761,7 @@ async function streamGeneration(res, provider, preset, context, generationType, 
     }
   } else if (capabilities.requiresPolling) {
     // Handle queue-based providers (AI Horde)
-    const streamWithStatus = provider.generateStreamingWithStatus(systemPrompt, effectiveUserPrompt, {
+    const streamWithStatus = provider.generateStreamingWithStatus(systemPrompt, userPrompt, {
       // Pass all advanced sampling parameters
       ...preset.generationSettings,
       maxContextLength: preset.generationSettings.maxContextTokens,
@@ -799,27 +781,18 @@ async function streamGeneration(res, provider, preset, context, generationType, 
           }
         })}\n\n`);
       } else if (update.type === 'complete') {
-        // Send final content
-        let processedContent = update.content || '';
-        processedContent = processedContent.replace(/\*/g, '');
+
+        const processedContent = update.content?.replace(/\*/g, '') || '';
 
         // Restore images in the final content
-        let finalContent = processedContent;
-        if (imagePreserver.saved.length > 0) {
-          const { text: restoredContent, missing } = imagePreserver.restore(processedContent);
-          finalContent = restoredContent;
-          if (missing.length > 0) {
-            finalContent = restoredContent
-              ? restoredContent + '\n\n' + missing.map(m => m.original).join('\n')
-              : missing.map(m => m.original).join('\n');
-          }
-          console.log(`[ImagePreserver] Restored ${imagePreserver.saved.length} image(s), ${missing.length} missing`);
-        }
+        const finalContent = !imagePreserver 
+          ? processedContent 
+          : imagePreserver.restoreImages(processedContent)?.finalContent;
 
         res.write(`data: ${JSON.stringify({
           content: finalContent,
           finished: true,
-          imagesRestored: imagePreserver.saved.length > 0
+          imagesRestored: imagePreserver?.saved.length > 0
         })}\n\n`);
       }
 
@@ -827,43 +800,29 @@ async function streamGeneration(res, provider, preset, context, generationType, 
     }
   } else {
     // Fallback: non-streaming generation
-    const result = await provider.generate(systemPrompt, effectiveUserPrompt, {
+    const result = await provider.generate(systemPrompt, userPrompt, {
       // Pass all advanced sampling parameters
       ...preset.generationSettings,
       maxContextLength: preset.generationSettings.maxContextTokens
     });
 
-    let processedContent = result.content || '';
-    processedContent = processedContent.replace(/\*/g, '');
+    const processedContent = update.content?.replace(/\*/g, '') || '';
 
     // Restore images in the final content
-    let finalContent = processedContent;
-    if (imagePreserver.saved.length > 0) {
-      const { text: restoredContent, missing } = imagePreserver.restore(processedContent);
-      finalContent = restoredContent;
-      if (missing.length > 0) {
-        finalContent = restoredContent
-          ? restoredContent + '\n\n' + missing.map(m => m.original).join('\n')
-          : missing.map(m => m.original).join('\n');
-      }
-      console.log(`[ImagePreserver] Restored ${imagePreserver.saved.length} image(s), ${missing.length} missing`);
-    }
+    const finalContent = !imagePreserver 
+      ? processedContent 
+      : imagePreserver.restoreImages(processedContent)?.finalContent;
 
     res.write(`data: ${JSON.stringify({
       reasoning: result.reasoning || null,
       content: finalContent,
       finished: true,
-      imagesRestored: imagePreserver.saved.length > 0
+      imagesRestored: imagePreserver?.saved.length > 0
     })}\n\n`);
     if (res.flush) res.flush();
   }
 
-  // --- Image preservation: restore images in the final assembled content ---
-  if (imagePreserver.saved.length > 0) {
-    // The LLM response doesn't have images; we append them back.
-    // To do this properly for streaming, we buffer the full response
-    // and send a final SSE event with the restored content.
-    // For non-streaming this happens inline above.
+  if (imagePreserver?.saved.length > 0) {
     console.log(`[ImagePreserver] ${imagePreserver.saved.length} image(s) preserved`);
   }
 

--- a/server/src/routes/stories.js
+++ b/server/src/routes/stories.js
@@ -8,6 +8,7 @@ import { SqliteStorageService } from '../services/sqliteStorage.js';
 import { PromptBuilder } from '../services/prompt-builder.js';
 import { MacroProcessor } from '../services/macro-processor.js';
 import { LorebookActivator } from '../services/lorebook-activator.js';
+import { ImagePreserver } from '../services/image-preserver.js';
 import { getProvider } from '../services/provider-factory.js';
 import { createPresetFromSettings } from '../services/default-presets.js';
 
@@ -673,6 +674,17 @@ function setupSSE(res) {
 async function streamGeneration(res, provider, preset, context, generationType, params, abortSignal = null) {
   console.log(`[streamGeneration] Starting ${generationType}, signal present: ${!!abortSignal}, aborted: ${abortSignal?.aborted}`);
 
+  // --- Image preservation: extract embedded images before sending to the LLM ---
+  const imagePreserver = new ImagePreserver();
+  if (context.story?.content) {
+    const preserved = imagePreserver.preserve(context.story.content);
+    if (preserved !== context.story.content) {
+      console.log(`[ImagePreserver] Extracted ${imagePreserver.saved.length} image(s) from story content`);
+      // Temporarily replace story content with placeholders for the LLM
+      context.story.content = preserved;
+    }
+  }
+
   // Build both system and user prompts with proper context management
   const prompts = await provider.buildPrompts(
     {
@@ -693,11 +705,18 @@ async function streamGeneration(res, provider, preset, context, generationType, 
 
   const { system: systemPrompt, user: userPrompt } = prompts;
 
+  // For rewriteThirdPerson: append image preservation note so the prompt-aware placeholders survive
+  let effectiveUserPrompt = userPrompt;
+  if (generationType === 'rewriteThirdPerson' && imagePreserver.saved.length > 0) {
+    effectiveUserPrompt = userPrompt + '\n\nIMPORTANT: Preserve any markers like [WG_IMAGE_0], [WG_IMAGE_1] etc. (image references) exactly as they appear in the text above. Do not remove or modify them.';
+    console.log(`[ImagePreserver] Appended image-preservation note for ${generationType}`);
+  }
+
   // Send prompts for debugging
   res.write(`data: ${JSON.stringify({
     prompts: {
       system: systemPrompt,
-      user: userPrompt
+      user: effectiveUserPrompt
     }
   })}\n\n`);
 
@@ -709,7 +728,7 @@ async function streamGeneration(res, provider, preset, context, generationType, 
   if (capabilities.streaming) {
     console.log(`[streamGeneration] Using streaming provider, signal: ${!!abortSignal}`);
     // Start streaming generation
-    const { stream, metadata } = await provider.generateStreaming(systemPrompt, userPrompt, {
+    const { stream, metadata } = await provider.generateStreaming(systemPrompt, effectiveUserPrompt, {
       // Pass all advanced sampling parameters
       ...preset.generationSettings,
       maxContextLength: preset.generationSettings.maxContextTokens,
@@ -718,18 +737,36 @@ async function streamGeneration(res, provider, preset, context, generationType, 
 
     // Stream chunks
     try {
+      let fullContent = '';
+
       for await (const chunk of stream) {
         // Apply asterisk filtering server-side (core feature - always enabled)
         let processedContent = chunk.content || null;
         if (processedContent) {
           processedContent = processedContent.replace(/\*/g, '');
+          fullContent += processedContent;
         }
 
+        // Build the event data. If this is the final chunk and we have
+        // preserved images, restore them and send the final content inline.
         const data = {
           reasoning: chunk.reasoning || null,
           content: processedContent,
           finished: chunk.finished || false,
         };
+
+        if (chunk.finished && imagePreserver.saved.length > 0) {
+          // Restore images directly into the finished chunk
+          const { text: restoredContent, missing } = imagePreserver.restore(fullContent);
+          data.finalContent = restoredContent
+            ? missing.length > 0
+              ? restoredContent + '\n\n' + missing.map(m => m.original).join('\n')
+              : restoredContent
+            : missing.map(m => m.original).join('\n');
+          data.imagesRestored = true;
+          data.imagesPreserved = imagePreserver.saved.length;
+          data.imagesMissing = missing.length;
+        }
 
         res.write(`data: ${JSON.stringify(data)}\n\n`);
         if (res.flush) res.flush();
@@ -742,7 +779,7 @@ async function streamGeneration(res, provider, preset, context, generationType, 
     }
   } else if (capabilities.requiresPolling) {
     // Handle queue-based providers (AI Horde)
-    const streamWithStatus = provider.generateStreamingWithStatus(systemPrompt, userPrompt, {
+    const streamWithStatus = provider.generateStreamingWithStatus(systemPrompt, effectiveUserPrompt, {
       // Pass all advanced sampling parameters
       ...preset.generationSettings,
       maxContextLength: preset.generationSettings.maxContextTokens,
@@ -766,9 +803,23 @@ async function streamGeneration(res, provider, preset, context, generationType, 
         let processedContent = update.content || '';
         processedContent = processedContent.replace(/\*/g, '');
 
+        // Restore images in the final content
+        let finalContent = processedContent;
+        if (imagePreserver.saved.length > 0) {
+          const { text: restoredContent, missing } = imagePreserver.restore(processedContent);
+          finalContent = restoredContent;
+          if (missing.length > 0) {
+            finalContent = restoredContent
+              ? restoredContent + '\n\n' + missing.map(m => m.original).join('\n')
+              : missing.map(m => m.original).join('\n');
+          }
+          console.log(`[ImagePreserver] Restored ${imagePreserver.saved.length} image(s), ${missing.length} missing`);
+        }
+
         res.write(`data: ${JSON.stringify({
-          content: processedContent,
-          finished: true
+          content: finalContent,
+          finished: true,
+          imagesRestored: imagePreserver.saved.length > 0
         })}\n\n`);
       }
 
@@ -776,7 +827,7 @@ async function streamGeneration(res, provider, preset, context, generationType, 
     }
   } else {
     // Fallback: non-streaming generation
-    const result = await provider.generate(systemPrompt, userPrompt, {
+    const result = await provider.generate(systemPrompt, effectiveUserPrompt, {
       // Pass all advanced sampling parameters
       ...preset.generationSettings,
       maxContextLength: preset.generationSettings.maxContextTokens
@@ -785,12 +836,35 @@ async function streamGeneration(res, provider, preset, context, generationType, 
     let processedContent = result.content || '';
     processedContent = processedContent.replace(/\*/g, '');
 
+    // Restore images in the final content
+    let finalContent = processedContent;
+    if (imagePreserver.saved.length > 0) {
+      const { text: restoredContent, missing } = imagePreserver.restore(processedContent);
+      finalContent = restoredContent;
+      if (missing.length > 0) {
+        finalContent = restoredContent
+          ? restoredContent + '\n\n' + missing.map(m => m.original).join('\n')
+          : missing.map(m => m.original).join('\n');
+      }
+      console.log(`[ImagePreserver] Restored ${imagePreserver.saved.length} image(s), ${missing.length} missing`);
+    }
+
     res.write(`data: ${JSON.stringify({
       reasoning: result.reasoning || null,
-      content: processedContent,
-      finished: true
+      content: finalContent,
+      finished: true,
+      imagesRestored: imagePreserver.saved.length > 0
     })}\n\n`);
     if (res.flush) res.flush();
+  }
+
+  // --- Image preservation: restore images in the final assembled content ---
+  if (imagePreserver.saved.length > 0) {
+    // The LLM response doesn't have images; we append them back.
+    // To do this properly for streaming, we buffer the full response
+    // and send a final SSE event with the restored content.
+    // For non-streaming this happens inline above.
+    console.log(`[ImagePreserver] ${imagePreserver.saved.length} image(s) preserved`);
   }
 
   // Send done

--- a/server/src/services/character-parser.js
+++ b/server/src/services/character-parser.js
@@ -234,4 +234,24 @@ export class CharacterParser {
   static base64Decode(str) {
     return Buffer.from(str, 'base64').toString('utf8');
   }
+
+  /**
+   * Normalize character card data to ensure V2 format
+   * Handles both V2 format (with data wrapper) and flat format
+   * @param {Object} rawData - The raw parsed JSON data
+   * @returns {Object} - Normalized card data in V2 format
+   */
+  static normalizeCardData(rawData) {
+    // Support both V2 format (with data wrapper) and flat format
+    if (!rawData.data) {
+      // Treat the whole JSON as the data field
+      return {
+        spec: 'chara_card_v2',
+        spec_version: '2.0',
+        data: rawData
+      };
+    }
+    
+    return rawData;
+  }
 }

--- a/server/src/services/default-presets.js
+++ b/server/src/services/default-presets.js
@@ -68,6 +68,8 @@ Write in a narrative, novel-style format with proper paragraphs and dialogue.
 Maintain consistency with established characters and plot.
 Focus on showing rather than telling, with vivid descriptions and natural dialogue.
 
+LANGUAGE REQUIREMENT: You MUST write in the exact same language as the existing story content. Do NOT switch to English. If the story is in Spanish, write in Spanish. If in French, write in French. Match the language of the provided text exactly.
+
 === PERSPECTIVE ===
 Write only in third-person past tense perspective.
 Use he/she/they pronouns and past tense verbs (said, walked, thought, etc.).

--- a/server/src/services/image-preserver.js
+++ b/server/src/services/image-preserver.js
@@ -1,0 +1,133 @@
+/**
+ * Image Preserver Service
+ *
+ * Extracts embedded images (markdown and HTML img tags) from story content
+ * before sending to the LLM, replaces them with robust placeholders, and
+ * restores them after the LLM response comes back.
+ *
+ * This prevents the LLM from stripping or mangling image references during
+ * rewrites (third-person, continue, instruction, etc.).
+ */
+
+// Regex patterns for both image formats
+// Support both standard markdown image syntax and variants with spaces:
+// ![alt](url) and ![alt] (url)
+const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\s*\(([^)]+)\)/g;
+const HTML_IMAGE_RE = /<img[^>]+>/gi;
+
+// Also catch stale [IMAGE_X] placeholders left over from previous client-side
+// extraction attempts (before the server-side preserver existed).
+const STALE_PLACEHOLDER_RE = /\[IMAGE_(\d+)\]/g;
+
+// Dedicated WG placeholders we use during the current request
+const WG_PLACEHOLDER_RE = /\[WG_IMAGE_(\d+)\]/g;
+
+// Placeholder template — uses a dedicated marker that won't collide with
+// stale client-side placeholders like [IMAGE_X].
+// HTML comments (<!-- -->) get stripped by LLMs, so use plain text markers.
+const PLACEHOLDER_TEMPLATE = (idx) => `[WG_IMAGE_${idx}]`;
+
+export class ImagePreserver {
+  constructor() {
+    /** @type {{ original: string, placeholder: string }[]} */
+    this.saved = [];
+  }
+
+  /**
+   * Scan `text` for all embedded images (markdown + HTML <img>),
+   * replace each with a unique placeholder, and store the originals.
+   * Also handles stale [IMAGE_X] placeholders from previous client-side attempts.
+   *
+   * @param {string} text  The full story content
+   * @returns {string}     Text with images replaced by placeholders
+   */
+  preserve(text) {
+    if (!text) return text;
+
+    this.saved = [];
+    let idx = 0;
+    let result = text;
+
+    // --- Extract markdown images ![alt](url) ---
+    result = result.replace(MARKDOWN_IMAGE_RE, (match) => {
+      const placeholder = PLACEHOLDER_TEMPLATE(idx);
+      this.saved.push({ original: match, placeholder, type: 'markdown' });
+      idx++;
+      return placeholder;
+    });
+
+    // --- Extract HTML <img ...> tags ---
+    result = result.replace(HTML_IMAGE_RE, (match) => {
+      const placeholder = PLACEHOLDER_TEMPLATE(idx);
+      this.saved.push({ original: match, placeholder, type: 'html' });
+      idx++;
+      return placeholder;
+    });
+
+    // --- Fallback: catch stale [IMAGE_X] placeholders from old client-side logic ---
+    // These are preserved as-is (they'll be restored by the client's fallback).
+    // Do NOT remap placeholders we generated in this request (WG_IMAGE_*)
+    result = result.replace(STALE_PLACEHOLDER_RE, (match) => {
+      const placeholder = PLACEHOLDER_TEMPLATE(idx);
+      this.saved.push({ original: match, placeholder, type: 'stale' });
+      idx++;
+      return placeholder;
+    });
+
+    return result;
+  }
+
+  /**
+   * Restore original images into the LLM's response by finding each
+   * surviving placeholder.  Placeholders the LLM removed are collected
+   * and returned separately so the caller can decide how to handle them
+   * (e.g. append at the end of the document).
+   *
+   * @param {string} response  The raw LLM response text
+   * @returns {{ text: string, missing: { original: string, placeholder: string }[] }}
+   *   - text:    response with placeholders restored
+   *   - missing: images whose placeholder was not found (lost by the LLM)
+   */
+  restore(response) {
+    if (!response) return { text: response || '', missing: [...this.saved] };
+
+    let text = response;
+    const missing = [];
+
+    for (const item of this.saved) {
+      if (text.includes(item.placeholder)) {
+        text = text.split(item.placeholder).join(item.original);
+      } else {
+        missing.push(item);
+      }
+    }
+
+    return { text, missing };
+  }
+
+  /**
+   * Convenience: run preserve → (prompt-building happens) → restore.
+   * `missing` images are appended to the end of the restored text.
+   *
+   * @param {string} rawContent    Original story content with embedded images
+   * @param {string} llmResponse   Response from the LLM
+   * @returns {string}             Final content with images restored (missing ones appended)
+   */
+  process(rawContent, llmResponse) {
+    this.preserve(rawContent);
+    const { text, missing } = this.restore(llmResponse);
+
+    // Append any images the LLM removed at the end
+    if (missing.length > 0) {
+      const appended = missing.map((m) => m.original).join('\n');
+      return text ? `${text}\n\n${appended}` : appended;
+    }
+
+    return text;
+  }
+
+  /** Reset saved images (e.g. between generations) */
+  reset() {
+    this.saved = [];
+  }
+}

--- a/server/src/services/image-preserver.js
+++ b/server/src/services/image-preserver.js
@@ -9,21 +9,10 @@
  * rewrites (third-person, continue, instruction, etc.).
  */
 
-// Regex patterns for both image formats
-// Support both standard markdown image syntax and variants with spaces:
-// ![alt](url) and ![alt] (url)
-const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\s*\(([^)]+)\)/g;
-const HTML_IMAGE_RE = /<img[^>]+>/gi;
+// Import shared regex patterns
+import { MARKDOWN_IMAGE_RE, HTML_IMAGE_RE, WG_PLACEHOLDER_RE } from '../../../shared/regex-patterns.js';
 
-// Also catch stale [IMAGE_X] placeholders left over from previous client-side
-// extraction attempts (before the server-side preserver existed).
-const STALE_PLACEHOLDER_RE = /\[IMAGE_(\d+)\]/g;
-
-// Dedicated WG placeholders we use during the current request
-const WG_PLACEHOLDER_RE = /\[WG_IMAGE_(\d+)\]/g;
-
-// Placeholder template — uses a dedicated marker that won't collide with
-// stale client-side placeholders like [IMAGE_X].
+// Placeholder template — uses a dedicated marker.
 // HTML comments (<!-- -->) get stripped by LLMs, so use plain text markers.
 const PLACEHOLDER_TEMPLATE = (idx) => `[WG_IMAGE_${idx}]`;
 
@@ -36,7 +25,6 @@ export class ImagePreserver {
   /**
    * Scan `text` for all embedded images (markdown + HTML <img>),
    * replace each with a unique placeholder, and store the originals.
-   * Also handles stale [IMAGE_X] placeholders from previous client-side attempts.
    *
    * @param {string} text  The full story content
    * @returns {string}     Text with images replaced by placeholders
@@ -64,16 +52,6 @@ export class ImagePreserver {
       return placeholder;
     });
 
-    // --- Fallback: catch stale [IMAGE_X] placeholders from old client-side logic ---
-    // These are preserved as-is (they'll be restored by the client's fallback).
-    // Do NOT remap placeholders we generated in this request (WG_IMAGE_*)
-    result = result.replace(STALE_PLACEHOLDER_RE, (match) => {
-      const placeholder = PLACEHOLDER_TEMPLATE(idx);
-      this.saved.push({ original: match, placeholder, type: 'stale' });
-      idx++;
-      return placeholder;
-    });
-
     return result;
   }
 
@@ -83,6 +61,10 @@ export class ImagePreserver {
    * and returned separately so the caller can decide how to handle them
    * (e.g. append at the end of the document).
    *
+   * Uses a single regex pass with a placeholder→original map for O(n) performance.
+   * Only the first occurrence of each placeholder is replaced; subsequent
+   * duplicates are removed to prevent image duplication.
+   *
    * @param {string} response  The raw LLM response text
    * @returns {{ text: string, missing: { original: string, placeholder: string }[] }}
    *   - text:    response with placeholders restored
@@ -91,43 +73,81 @@ export class ImagePreserver {
   restore(response) {
     if (!response) return { text: response || '', missing: [...this.saved] };
 
-    let text = response;
-    const missing = [];
-
+    const placeholderMap = new Map();
     for (const item of this.saved) {
-      if (text.includes(item.placeholder)) {
-        text = text.split(item.placeholder).join(item.original);
-      } else {
-        missing.push(item);
-      }
+      placeholderMap.set(item.placeholder, item.original);
     }
 
-    return { text, missing };
+    // Track which placeholders have been replaced (to handle duplicates)
+    const replacedPlaceholders = new Set();
+
+    // Track which placeholders were found
+    const foundPlaceholders = new Set();
+
+    // Reset lastIndex to avoid issues from previous calls
+    WG_PLACEHOLDER_RE.lastIndex = 0;
+
+    // Single regex pass to replace all placeholders
+    const result = response.replace(WG_PLACEHOLDER_RE, (match) => {
+      if (!placeholderMap.has(match)) {
+        return match; // Not one of ours, leave unchanged
+      }
+
+      foundPlaceholders.add(match);
+
+      if (replacedPlaceholders.has(match)) {
+        // This placeholder appeared more than once - only replace the first occurrence
+        // Return empty string for subsequent occurrences to avoid duplication
+        return '';
+      }
+
+      replacedPlaceholders.add(match);
+      return placeholderMap.get(match);
+    });
+
+    // Detect missing: placeholders that were saved but not found in response
+    const missing = this.saved.filter(item => !foundPlaceholders.has(item.placeholder));
+
+    return { text: result, missing };
   }
 
   /**
-   * Convenience: run preserve → (prompt-building happens) → restore.
-   * `missing` images are appended to the end of the restored text.
+   * Restore preserved images back into the LLM response.
    *
-   * @param {string} rawContent    Original story content with embedded images
-   * @param {string} llmResponse   Response from the LLM
-   * @returns {string}             Final content with images restored (missing ones appended)
+   * Surviving placeholders are replaced with the original image markup.
+   * Placeholders the LLM removed (missing images) are appended at the end.
+   * If the LLM returned empty or whitespace-only content, the original
+   * response is returned as-is and nothing is restored.
+   *
+   * @param {string} llmResponse  Raw text returned by the LLM
+   * @returns {{ finalContent: string, imagesRestored: boolean, imagesPreserved: number, imagesMissing: number }}
    */
-  process(rawContent, llmResponse) {
-    this.preserve(rawContent);
-    const { text, missing } = this.restore(llmResponse);
-
-    // Append any images the LLM removed at the end
-    if (missing.length > 0) {
-      const appended = missing.map((m) => m.original).join('\n');
-      return text ? `${text}\n\n${appended}` : appended;
+  restoreImages(llmResponse) {
+    // Guard against empty/failed LLM response
+    const hasContent = llmResponse && llmResponse.trim().length > 0;
+    if (!hasContent || this.saved.length === 0) {
+      return {
+        finalContent: llmResponse || '',
+        imagesRestored: false,
+        imagesPreserved: 0,
+        imagesMissing: 0
+      };
     }
 
-    return text;
-  }
+    const { text: restoredContent, missing } = this.restore(llmResponse);
 
-  /** Reset saved images (e.g. between generations) */
-  reset() {
-    this.saved = [];
+    // Build final content with missing images appended at the end
+    let finalContent = restoredContent;
+    if (missing.length > 0) {
+      finalContent += '\n\n' + missing.map(m => m.original).join('\n');
+    }
+
+    console.log(`[ImagePreserver] Restored ${this.saved.length} image(s), ${missing.length} missing`);
+    return {
+      finalContent,
+      imagesRestored: true,
+      imagesPreserved: this.saved.length,
+      imagesMissing: missing.length
+    };
   }
 }

--- a/server/src/services/prompt-builder.js
+++ b/server/src/services/prompt-builder.js
@@ -321,7 +321,7 @@ export class PromptBuilder {
    * Build generation prompt based on type
    */
   buildGenerationPrompt(type, params) {
-    const { storyContent, characterName, customInstruction, templateText, maxChars, userName } = params;
+    const { storyContent, characterName, customInstruction, templateText, maxChars, userName, imagePreserver } = params;
 
     let storyContext = "";
     let instruction = "";
@@ -343,13 +343,17 @@ export class PromptBuilder {
         instruction = instruction.replace(/\{\{instruction\}\}/g, customInstruction);
       }
       if (storyContent) {
-        instruction = instruction.replace(/\{\{storyContent\}\}/g, storyContent);
+        // Preserve images before replacing into template
+        const preservedStoryContent = imagePreserver ? imagePreserver.preserve(storyContent) : storyContent;
+        instruction = instruction.replace(/\{\{storyContent\}\}/g, preservedStoryContent);
       }
       instruction = instruction.replace(/\{\{user\}\}/gi, userName || 'the user');
 
       // If template doesn't use {{storyContent}}, add story context separately
       if (storyContent && storyContent.trim() && !templateText.includes('{{storyContent}}')) {
-        storyContext = this.truncateStoryContent(storyContent, maxChars);
+        const truncated = this.truncateStoryContent(storyContent, maxChars);
+        // Preserve images in the truncated content (only content that survives truncation)
+        storyContext = imagePreserver ? imagePreserver.preserve(truncated) : truncated;
       }
     } else {
       // Use default templates
@@ -394,14 +398,24 @@ export class PromptBuilder {
         instruction = instruction.replace(/\{\{instruction\}\}/g, customInstruction);
       }
       if (storyContent) {
-        instruction = instruction.replace(/\{\{storyContent\}\}/g, storyContent);
+        // Preserve images before replacing into template
+        const preservedStoryContent = imagePreserver ? imagePreserver.preserve(storyContent) : storyContent;
+        instruction = instruction.replace(/\{\{storyContent\}\}/g, preservedStoryContent);
       }
       instruction = instruction.replace(/\{\{user\}\}/gi, userName || 'the user');
 
       // Only add story context separately if template doesn't use {{storyContent}}
       if (storyContent && storyContent.trim() && !defaultTemplate.includes('{{storyContent}}')) {
-        storyContext = this.truncateStoryContent(storyContent, maxChars);
+        const truncated = this.truncateStoryContent(storyContent, maxChars);
+        // Preserve images in the truncated content (only content that survives truncation)
+        storyContext = imagePreserver ? imagePreserver.preserve(truncated) : truncated;
       }
+    }
+
+      // For rewriteThirdPerson: append image preservation note so the prompt-aware placeholders survive
+    if (imagePreserver && imagePreserver.saved.length > 0) {
+      instruction += '\n\nIMPORTANT: Preserve any markers like [WG_IMAGE_0], [WG_IMAGE_1] etc. (image references) exactly as they appear in the text above. Do not remove or modify them.';
+      console.log(`[ImagePreserver] Appended image-preservation note for ${type}`);
     }
 
     return storyContext + instruction;
@@ -443,7 +457,8 @@ export class PromptBuilder {
       customInstruction,
       templateText,
       systemPromptTemplate = null,
-      userName
+      userName,
+      imagePreserver = null
     } = options;
 
     // Build system prompt first (with custom template if provided and not null)
@@ -470,7 +485,8 @@ export class PromptBuilder {
       customInstruction,
       templateText,
       maxChars: availableChars,
-      userName
+      userName,
+      imagePreserver
     });
 
     return {

--- a/server/src/services/providers/aihorde-provider.js
+++ b/server/src/services/providers/aihorde-provider.js
@@ -114,6 +114,8 @@ export class AIHordeProvider extends LLMProvider {
       maxContextTokens,
       maxGenerationTokens,
       generationType,
+      // Pass imagePreserver if provided (for preserving images after truncation)
+      imagePreserver: customParams.imagePreserver || null,
       ...customParams
     });
   }

--- a/server/src/services/providers/base-provider.js
+++ b/server/src/services/providers/base-provider.js
@@ -102,6 +102,8 @@ export class LLMProvider {
       maxGenerationTokens,
       generationType,
       systemPromptTemplate,
+      // Pass imagePreserver if provided (for preserving images after truncation)
+      imagePreserver: customParams.imagePreserver || null,
       ...customParams
     });
   }

--- a/server/src/services/providers/shared/stream-parser.js
+++ b/server/src/services/providers/shared/stream-parser.js
@@ -18,6 +18,7 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let emittedFinished = false;
 
   try {
     while (true) {
@@ -34,7 +35,18 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
       for (const line of lines) {
         const trimmed = line.trim();
 
-        if (trimmed === "" || trimmed === "data: [DONE]") {
+        if (trimmed === "") {
+          continue;
+        }
+
+        // Some providers only signal completion with [DONE] and never send
+        // a final chunk containing finish_reason. Emit a synthetic final chunk
+        // so downstream code can run finalization (e.g. image restoration).
+        if (trimmed === "data: [DONE]") {
+          if (!emittedFinished) {
+            emittedFinished = true;
+            yield { reasoning: null, content: null, finished: true };
+          }
           continue;
         }
 
@@ -46,13 +58,16 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
             if (data.choices && data.choices[0]) {
               const delta = data.choices[0].delta;
               const finishReason = data.choices[0].finish_reason;
+              const finished = finishReason !== null;
 
               // Use the transform function to extract provider-specific fields
               const result = transformDelta(delta, data);
 
+              if (finished) emittedFinished = true;
+
               yield {
                 ...result,
-                finished: finishReason !== null,
+                finished,
               };
             }
           } catch (e) {
@@ -60,6 +75,11 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
           }
         }
       }
+    }
+
+    // If stream ended without an explicit finished chunk, emit one.
+    if (!emittedFinished) {
+      yield { reasoning: null, content: null, finished: true };
     }
   } catch (error) {
     if (error.name === 'AbortError') {

--- a/server/src/services/providers/shared/stream-parser.js
+++ b/server/src/services/providers/shared/stream-parser.js
@@ -35,18 +35,7 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
       for (const line of lines) {
         const trimmed = line.trim();
 
-        if (trimmed === "") {
-          continue;
-        }
-
-        // Some providers only signal completion with [DONE] and never send
-        // a final chunk containing finish_reason. Emit a synthetic final chunk
-        // so downstream code can run finalization (e.g. image restoration).
-        if (trimmed === "data: [DONE]") {
-          if (!emittedFinished) {
-            emittedFinished = true;
-            yield { reasoning: null, content: null, finished: true };
-          }
+        if (trimmed === "" || trimmed === "data: [DONE]") {
           continue;
         }
 
@@ -58,16 +47,13 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
             if (data.choices && data.choices[0]) {
               const delta = data.choices[0].delta;
               const finishReason = data.choices[0].finish_reason;
-              const finished = finishReason !== null;
 
               // Use the transform function to extract provider-specific fields
               const result = transformDelta(delta, data);
 
-              if (finished) emittedFinished = true;
-
               yield {
                 ...result,
-                finished,
+                finished: finishReason !== null,              
               };
             }
           } catch (e) {
@@ -75,11 +61,6 @@ export async function* parseSSEStream(body, transformDelta, providerName = 'Prov
           }
         }
       }
-    }
-
-    // If stream ended without an explicit finished chunk, emit one.
-    if (!emittedFinished) {
-      yield { reasoning: null, content: null, finished: true };
     }
   } catch (error) {
     if (error.name === 'AbortError') {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/shared/regex-patterns.js
+++ b/shared/regex-patterns.js
@@ -1,0 +1,19 @@
+/**
+ * Shared regex patterns for markdown and HTML image handling
+ * Used by both server-side (image-preserver.js) and client-side (StoryEditor.vue) code
+ */
+
+// Regex pattern for markdown images: ![alt](url) and ![alt] (url)
+// Uses balanced-parentheses URL capture to handle URLs with ) e.g. File_(2020).jpg
+// No whitespace allowed in URL portion, horizontal whitespace only between ] and (
+export const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\][ \t]*\(([^\s()]*(?:\([^\s()]*\)[^\s()]*)*)\)/g;
+
+// Regex pattern for normalizing markdown image spacing: ![alt] (url) -> ![alt](url)
+// Only matches when there's horizontal whitespace between ] and ( (requires at least one space)
+export const MARKDOWN_IMAGE_NORMALIZE_RE = /!\[([^\]]*)\][ \t]+\(([^\s()]*(?:\([^\s()]*\)[^\s()]*)*)\)/g;
+
+// Regex pattern for HTML <img ...> tags
+export const HTML_IMAGE_RE = /<img[^>]+>/gi;
+
+// Regex pattern for WG placeholders: [WG_IMAGE_X]
+export const WG_PLACEHOLDER_RE = /\[WG_IMAGE_(\d+)\]/g;

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -16,10 +16,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "dompurify": "^3.4.11",
     "vue": "^3.5.24",
     "vue-router": "^4.6.3"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^4.0.9",
     "@vue/test-utils": "^2.4.6",

--- a/vue_client/src/components/ImportCharacterModal.vue
+++ b/vue_client/src/components/ImportCharacterModal.vue
@@ -1,24 +1,48 @@
 <template>
   <Modal title="Import Character" @close="$emit('close')">
     <div class="import-content">
-      <!-- Import from PNG -->
+      <!-- Import from Photos -->
       <section class="import-section">
-        <h3><i class="fas fa-image"></i> Import from PNG</h3>
-        <p class="help-text">Upload a character card image (PNG format)</p>
+        <h3><i class="fas fa-images"></i> Import from Photos</h3>
+        <p class="help-text">Pick a character card image from your photo gallery</p>
         <input
           ref="fileInput"
           type="file"
-          accept="image/png"
+          accept="image/png,image/jpeg"
           @change="handleFileSelect"
           class="file-input"
         />
         <button
           class="btn btn-primary full-width"
           :disabled="!selectedFile || importing"
-          @click="importFromPNG"
+          @click="importFromPhoto"
         >
           <i class="fas fa-upload"></i>
-          {{ importing ? 'Importing...' : 'Import PNG' }}
+          {{ importing ? 'Importing...' : 'Import from Photos' }}
+        </button>
+      </section>
+
+      <div class="divider">
+        <span>OR</span>
+      </div>
+
+      <!-- Import from Storage -->
+      <section class="import-section">
+        <h3><i class="fas fa-folder-open"></i> Import from Storage</h3>
+        <p class="help-text">Browse local files for character card JSON or images</p>
+        <input
+          ref="storageFileInput"
+          type="file"
+          @change="handleStorageFileSelect"
+          class="file-input"
+        />
+        <button
+          class="btn btn-primary full-width"
+          :disabled="!selectedStorageFile || importing"
+          @click="importFromStorage"
+        >
+          <i class="fas fa-upload"></i>
+          {{ importing ? 'Importing...' : 'Import from Storage' }}
         </button>
       </section>
 
@@ -62,6 +86,8 @@ const toast = useToast()
 
 const selectedFile = ref(null)
 const fileInput = ref(null)
+const selectedStorageFile = ref(null)
+const storageFileInput = ref(null)
 const characterUrl = ref('')
 const importing = ref(false)
 
@@ -72,7 +98,14 @@ function handleFileSelect(event) {
   }
 }
 
-async function importFromPNG() {
+function handleStorageFileSelect(event) {
+  const file = event.target.files[0]
+  if (file) {
+    selectedStorageFile.value = file
+  }
+}
+
+async function importFromPhoto() {
   if (!selectedFile.value || importing.value) return
 
   try {
@@ -83,7 +116,7 @@ async function importFromPNG() {
     emit('imported', result)
     emit('close')
   } catch (error) {
-    console.error('Failed to import PNG:', error)
+    console.error('Failed to import photo:', error)
     toast.error('Failed to import character: ' + error.message)
   } finally {
     importing.value = false
@@ -102,6 +135,35 @@ async function importFromURL() {
     emit('close')
   } catch (error) {
     console.error('Failed to import from URL:', error)
+    toast.error('Failed to import character: ' + error.message)
+  } finally {
+    importing.value = false
+  }
+}
+
+async function importFromStorage() {
+  if (!selectedStorageFile.value || importing.value) return
+
+  try {
+    importing.value = true
+
+    // Detect if it's an image file (PNG/JPEG) and route accordingly
+    const file = selectedStorageFile.value
+    const isImage = file.type === 'image/png' || file.type === 'image/jpeg' ||
+      file.name.match(/\.(png|jpg|jpeg|webp)$/i)
+
+    let result
+    if (isImage) {
+      result = await charactersAPI.importPNG(file)
+    } else {
+      result = await charactersAPI.importJSON(file)
+    }
+
+    toast.success(`Successfully imported "${result.name}"!`)
+    emit('imported', result)
+    emit('close')
+  } catch (error) {
+    console.error('Failed to import character from storage:', error)
     toast.error('Failed to import character: ' + error.message)
   } finally {
     importing.value = false

--- a/vue_client/src/services/api.js
+++ b/vue_client/src/services/api.js
@@ -476,6 +476,24 @@ export const charactersAPI = {
     return response.json()
   },
 
+  async importJSON(file) {
+    const formData = new FormData()
+    formData.append('character', file)
+
+    const url = `${baseURL}/characters/import-json`
+    const response = await fetch(url, {
+      method: 'POST',
+      body: formData,
+    })
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: response.statusText }))
+      throw new Error(error.error || `Request failed: ${response.statusText}`)
+    }
+
+    return response.json()
+  },
+
   async importFromURL(url) {
     return request('/characters/import-url', {
       method: 'POST',

--- a/vue_client/src/style.css
+++ b/vue_client/src/style.css
@@ -51,6 +51,7 @@ body {
   color: var(--text-primary);
   line-height: 1.6;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/vue_client/src/views/CharacterDetail.vue
+++ b/vue_client/src/views/CharacterDetail.vue
@@ -466,7 +466,6 @@ const { confirm } = useConfirm()
 const loading = ref(true)
 const character = ref(null)
 const availableLorebooks = ref([])
-const isDefaultPersona = ref(false)
 
 // Greeting selector state for new story flow
 const showGreetingSelector = ref(false)

--- a/vue_client/src/views/CharacterDetail.vue
+++ b/vue_client/src/views/CharacterDetail.vue
@@ -429,6 +429,14 @@
       <p>Failed to load character</p>
     </div>
   </div>
+
+  <!-- Greeting Selector Modal -->
+  <GreetingSelectorModal
+    v-if="showGreetingSelector"
+    :story="createdStoryForModal"
+    @close="handleGreetingModalClose"
+    @select="handleGreetingSelect"
+  />
 </template>
 
 <script setup>
@@ -440,6 +448,7 @@ import { useNavigation } from '../composables/useNavigation'
 import { useConfirm } from '../composables/useConfirm'
 import { setPageTitle } from '../router'
 import CharacterCard from '../components/CharacterCard.vue'
+import GreetingSelectorModal from '../components/GreetingSelectorModal.vue'
 
 const props = defineProps({
   characterId: {
@@ -457,8 +466,12 @@ const { confirm } = useConfirm()
 const loading = ref(true)
 const character = ref(null)
 const availableLorebooks = ref([])
+const isDefaultPersona = ref(false)
 
-// Editing states
+// Greeting selector state for new story flow
+const showGreetingSelector = ref(false)
+const createdStoryId = ref(null)
+const createdStoryForModal = ref(null)
 const editingName = ref(false)
 const editingDescription = ref(false)
 const editingLorebook = ref(false)
@@ -880,18 +893,41 @@ async function createNewStory() {
     // Add character to story
     const response = await charactersAPI.addToStory(story.id, props.characterId)
 
-    // Add first message if available
-    if (response.processedFirstMessage) {
-      await storiesAPI.updateContent(story.id, response.processedFirstMessage + '\n\n')
+    // Store story info for greeting selector
+    createdStoryId.value = story.id
+    createdStoryForModal.value = {
+      id: story.id,
+      characterIds: [props.characterId]
     }
 
-    toast.success('Story created!')
-
-    // Navigate to the new story
-    router.push(`/story/${story.id}`)
+    // Show greeting selector instead of navigating immediately
+    showGreetingSelector.value = true
   } catch (error) {
     console.error('Failed to create story:', error)
     toast.error('Failed to create story: ' + error.message)
+  }
+}
+
+async function handleGreetingSelect(greeting) {
+  try {
+    // Add selected greeting to story
+    await storiesAPI.updateContent(createdStoryId.value, greeting + '\n\n')
+    toast.success('Story created with greeting!')
+  } catch (error) {
+    console.error('Failed to add greeting to story:', error)
+    // Continue anyway - story is created, just navigate
+  }
+
+  // Navigate to the new story
+  showGreetingSelector.value = false
+  router.push(`/story/${createdStoryId.value}`)
+}
+
+function handleGreetingModalClose() {
+  // User closed without selecting - navigate to story anyway
+  showGreetingSelector.value = false
+  if (createdStoryId.value) {
+    router.push(`/story/${createdStoryId.value}`)
   }
 }
 

--- a/vue_client/src/views/LandingPage.vue
+++ b/vue_client/src/views/LandingPage.vue
@@ -341,13 +341,10 @@ async function createStoryWithCharacter(characterId) {
     const { story } = await storiesAPI.create(`Story with ${characterName}`)
 
     // Add character to story
-    const response = await charactersAPI.addToStory(story.id, characterId)
+    await charactersAPI.addToStory(story.id, characterId)
 
-    // If there's a first message, add it and set the rewrite prompt flag
-    if (response.processedFirstMessage) {
-      await storiesAPI.updateContent(story.id, response.processedFirstMessage + '\n\n')
-      await storiesAPI.setRewritePrompt(story.id, true)
-    }
+    // Set rewrite prompt flag so StoryEditor shows the greeting selector on load
+    await storiesAPI.setRewritePrompt(story.id, true)
 
     // Invalidate stories cache so it refreshes when returning to dashboard
     invalidateCache('stories')

--- a/vue_client/src/views/OnboardingWizard.vue
+++ b/vue_client/src/views/OnboardingWizard.vue
@@ -587,7 +587,8 @@ function finishOnboarding() {
   max-width: 600px;
   width: 100%;
   position: relative;
-  overflow: hidden;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .progress-bar {

--- a/vue_client/src/views/StoryEditor.vue
+++ b/vue_client/src/views/StoryEditor.vue
@@ -330,7 +330,11 @@ import { useToast } from '../composables/useToast'
 import { useNavigation } from '../composables/useNavigation'
 import { useConfirm } from '../composables/useConfirm'
 import { setPageTitle } from '../router'
-import { MARKDOWN_IMAGE_RE, MARKDOWN_IMAGE_NORMALIZE_RE, HTML_IMAGE_RE } from '../../../shared/regex-patterns.js'
+import {
+  MARKDOWN_IMAGE_RE,
+  MARKDOWN_IMAGE_NORMALIZE_RE,
+  HTML_IMAGE_RE,
+} from '../../../shared/regex-patterns.js'
 import DOMPurify from 'dompurify'
 import ReasoningPanel from '../components/ReasoningPanel.vue'
 import CharacterResponseModal from '../components/CharacterResponseModal.vue'
@@ -394,7 +398,7 @@ const bottomInputRef = ref(null)
 // Check if story has images
 const hasImages = computed(() => {
   if (!content.value) return false
-  return /!\[[^\]]*\]\s*\([^)]+\)/.test(content.value) || /<img[^>]*>/i.test(content.value)
+  return MARKDOWN_IMAGE_RE.test(content.value) || HTML_IMAGE_RE.test(content.value)
 })
 
 // Avatar windows (stored on server per-story)
@@ -1106,6 +1110,10 @@ function cancelGeneration() {
 
 async function selectGreeting(greeting) {
   content.value = greeting + '\n\n'
+  // Switch to preview mode if the greeting contains images
+  if (hasImages.value) {
+    showPreview.value = true
+  }
   await saveStory()
   showGreetingSelector.value = false
   toast.success('Greeting selected')

--- a/vue_client/src/views/StoryEditor.vue
+++ b/vue_client/src/views/StoryEditor.vue
@@ -11,6 +11,14 @@
       <div class="header-right">
         <button
           class="icon-btn"
+          :class="{ 'icon-btn-active': showPreview }"
+          @click="showPreview = !showPreview"
+          :title="showPreview ? 'Switch to editor' : 'Preview rendered content'"
+        >
+          <i class="fas fa-eye"></i>
+        </button>
+        <button
+          class="icon-btn"
           @click="showManageCharacters = true"
           title="Manage Characters"
         >
@@ -63,9 +71,10 @@
         @close="showReasoningPanel = false"
       />
 
-      <!-- Text Editor -->
+      <!-- Text Editor / Preview -->
       <div class="editor-container">
         <textarea
+          v-if="!showPreview"
           ref="editorRef"
           v-model="content"
           class="story-editor"
@@ -73,6 +82,26 @@
           spellcheck="true"
           @input="handleInput"
         ></textarea>
+        <div v-else class="story-preview" v-html="renderedContent"></div>
+        
+        <!-- Bottom input bar for preview mode -->
+        <div v-if="showPreview" class="preview-input-bar">
+          <input
+            ref="bottomInputRef"
+            v-model="bottomInput"
+            type="text"
+            class="preview-input"
+            placeholder="Type a message..."
+            @keydown.enter="handleBottomInputSend"
+          />
+          <button
+            class="btn btn-primary btn-send"
+            :disabled="!bottomInput.trim()"
+            @click="handleBottomInputSend"
+          >
+            <i class="fas fa-paper-plane"></i> Send
+          </button>
+        </div>
       </div>
 
       <!-- Bottom Toolbar -->
@@ -352,7 +381,18 @@ const ideateResponse = ref('')
 const ideateLoading = ref(false)
 const ideateStatus = ref('Thinking...')
 const showThirdPersonPrompt = ref(false)
+const showPreview = ref(false)
 let abortController = null
+
+// Bottom input for preview mode
+const bottomInput = ref('')
+const bottomInputRef = ref(null)
+
+// Check if story has images
+const hasImages = computed(() => {
+  if (!content.value) return false
+  return /!\[[^\]]*\]\s*\([^)]+\)/.test(content.value) || /<img[^>]*>/i.test(content.value)
+})
 
 // Avatar windows (stored on server per-story)
 const avatarWindows = ref([])
@@ -363,6 +403,25 @@ const shouldShowReasoning = ref(false) // Setting from server
 // Computed: is story content empty?
 const isStoryEmpty = computed(() => {
   return !content.value || content.value.trim().length === 0
+})
+
+// Computed: rendered content with markdown images converted to HTML
+const renderedContent = computed(() => {
+  if (!content.value) return ''
+  // Escape HTML special chars first
+  let html = content.value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+  // Convert markdown images: ![alt](url) and ![alt] (url)
+  html = html.replace(/!\[([^\]]*)\]\s*\(([^)]+)\)/g, '<img src="$2" alt="$1" class="story-image" loading="lazy">')
+  // Convert double newlines to paragraphs
+  html = '<p>' + html.replace(/\n\n/g, '</p><p>') + '</p>'
+  // Convert single newlines to <br>
+  html = html.replace(/\n/g, '<br>')
+  // Remove empty paragraphs
+  html = html.replace(/<p><\/p>/g, '')
+  return html
 })
 
 // Auto-save
@@ -378,6 +437,12 @@ const undoRedoInProgress = ref(false) // Prevents rapid concurrent undo/redo ope
 function normalizeTrailingLineBreaks() {
   const trimmed = content.value.replace(/\n+$/, '')
   content.value = trimmed + '\n\n'
+}
+
+// Normalize markdown image syntax spacing: ![alt] (url) -> ![alt](url)
+function normalizeMarkdownImageSpacing(text) {
+  if (!text) return text
+  return text.replace(/!\[([^\]]*)\]\s+\(([^)]+)\)/g, '![$1]($2)')
 }
 
 // Keyboard shortcut handler for quick paragraph generation, modal opening, and undo/redo
@@ -430,10 +495,29 @@ onMounted(async () => {
     avatarWindows.value = story.value.avatarWindows
   }
 
+  // Set preview mode as default if story has images
+  if (hasImages.value) {
+    showPreview.value = true
+  }
+
   // Add keyboard shortcut listener
   window.addEventListener('keydown', handleKeyboardShortcut)
 
-  // Check if we should prompt for third-person rewrite (from story creation with first message)
+  // Check if we should show greeting selector first (for newly created stories with characters)
+  if (story.value?.needsRewritePrompt && story.value?.characterIds?.length > 0) {
+    // Clear the flag on the server
+    try {
+      await storiesAPI.setRewritePrompt(props.storyId, false)
+    } catch (error) {
+      console.error('Failed to clear rewrite prompt flag:', error)
+    }
+    
+    // Show greeting selector FIRST before rewrite dialog
+    showGreetingSelector.value = true
+    return
+  }
+  
+  // If we don't need to show greeting selector, check if we should show rewrite dialog
   if (story.value?.needsRewritePrompt) {
     // Clear the flag on the server
     try {
@@ -546,13 +630,21 @@ async function loadSettings() {
 }
 
 async function saveStory(silent = false) {
-  if (content.value === originalContent.value) {
+  const normalizedContent = normalizeMarkdownImageSpacing(content.value)
+  const normalizedOriginal = normalizeMarkdownImageSpacing(originalContent.value)
+
+  // Keep editor content canonical when save is triggered
+  if (normalizedContent !== content.value) {
+    content.value = normalizedContent
+  }
+
+  if (normalizedContent === normalizedOriginal) {
     return // No changes
   }
 
   try {
-    const result = await storiesAPI.updateContent(props.storyId, content.value)
-    originalContent.value = content.value
+    const result = await storiesAPI.updateContent(props.storyId, normalizedContent)
+    originalContent.value = normalizedContent
 
     // Update history status from response
     if (result.canUndo !== undefined) {
@@ -654,6 +746,26 @@ async function handleRedo() {
     await nextTick()
     isUndoRedoOperation = false
     undoRedoInProgress.value = false
+  }
+}
+
+async function handleBottomInputSend() {
+  if (!bottomInput.value.trim() || generating.value) return
+
+  try {
+    // Add user message to content with newline before and after
+    const userMessage = bottomInput.value.trim()
+    content.value = content.value + '\n\n' + userMessage + '\n'
+    bottomInput.value = ''
+
+    // Save the story
+    await saveStory(true)
+
+    // Trigger character response
+    await handleCharacterResponse()
+  } catch (error) {
+    console.error('Failed to send message:', error)
+    toast.error('Failed to send message: ' + error.message)
   }
 }
 
@@ -807,8 +919,8 @@ async function generate(isCustom, instruction, characterId) {
     reasoning.value = ''
     showReasoningPanel.value = false  // Only open when reasoning is actually received
 
-    // Track cursor position
-    const cursorPos = editorRef.value.selectionStart
+    // Track cursor position (only if editor is visible)
+    const cursorPos = editorRef.value ? editorRef.value.selectionStart : content.value.length
     const textBefore = content.value.substring(0, cursorPos)
     const textAfter = content.value.substring(cursorPos)
 
@@ -956,7 +1068,8 @@ async function rewriteToThirdPerson(skipConfirm = false) {
     if (!confirmed) return
   }
 
-  // Save before rewriting
+  // Save the current content (with any embedded images) before rewriting
+  // The server-side ImagePreserver handles image extraction/restoration
   await saveStory(true)
 
   // Create abort controller for cancellation
@@ -1020,6 +1133,17 @@ async function rewriteToThirdPerson(skipConfirm = false) {
         content.value = rewrittenContent
 
         // Auto-scroll editor
+        await nextTick()
+        if (editorRef.value) {
+          editorRef.value.scrollTop = editorRef.value.scrollHeight
+        }
+      }
+
+      // Handle server-side image restoration event
+      if (chunk.imagesRestored && chunk.finalContent) {
+        // Server already restored images; use its final content directly
+        rewrittenContent = chunk.finalContent
+        content.value = rewrittenContent
         await nextTick()
         if (editorRef.value) {
           editorRef.value.scrollTop = editorRef.value.scrollHeight
@@ -1294,6 +1418,7 @@ function saveAvatarWindows() {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
   background-color: var(--bg-secondary);
 }
 
@@ -1349,6 +1474,8 @@ function saveAvatarWindows() {
   flex: 1;
   overflow: hidden;
   display: flex;
+  flex-direction: column;
+  position: relative;
 }
 
 .story-editor {
@@ -1461,6 +1588,104 @@ function saveAvatarWindows() {
 
 .stop-button {
   margin-left: auto;
+  white-space: nowrap;
+}
+
+.icon-btn-active {
+  color: var(--accent-primary) !important;
+}
+
+.icon-btn-active i {
+  color: var(--accent-primary) !important;
+}
+
+.story-preview {
+  width: 100%;
+  flex: 1;
+  overflow-y: auto;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  padding-left: max(2rem, calc((100% - 700px) / 2));
+  padding-right: max(2rem, calc((100% - 700px) / 2));
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 1rem;
+  line-height: 1.8;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: var(--shadow);
+}
+
+.story-preview p {
+  margin: 0 0 1em 0;
+}
+
+:deep(.story-preview .story-image) {
+  /* Responsive: scale image to viewport with adaptive margins */
+  width: auto;
+  height: auto;
+  display: block;
+  margin: 1rem auto;
+  border-radius: 8px;
+  object-fit: contain;
+}
+
+/* Small screens (phones) — keep some edge padding */
+@media (max-width: 480px) {
+  :deep(.story-preview .story-image) {
+    max-width: calc(100vw - 2rem);
+    max-height: 70vh;
+  }
+}
+
+/* Medium screens (tablets) */
+@media (min-width: 481px) and (max-width: 1024px) {
+  :deep(.story-preview .story-image) {
+    max-width: calc(100vw - 4rem);
+    max-height: 70vh;
+  }
+}
+
+/* Large screens (desktop) — cap width so images don't span edge-to-edge */
+@media (min-width: 1025px) {
+  :deep(.story-preview .story-image) {
+    max-width: min(100%, calc(100vw - 8rem), 800px);
+    max-height: calc(100vh - 10rem);
+  }
+}
+
+/* Preview input bar at bottom of editor when in preview mode */
+.editor-container {
+  position: relative;
+}
+
+.preview-input-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 2rem;
+  background-color: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.preview-input {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  font-size: 1rem;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.preview-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px rgba(139, 90, 43, 0.1);
+}
+
+.btn-send {
+  padding: 0.75rem 1.5rem;
   white-space: nowrap;
 }
 </style>

--- a/vue_client/src/views/StoryEditor.vue
+++ b/vue_client/src/views/StoryEditor.vue
@@ -82,7 +82,7 @@
           spellcheck="true"
           @input="handleInput"
         ></textarea>
-        <div v-else class="story-preview" v-html="renderedContent"></div>
+        <div v-else ref="previewRef" class="story-preview" v-html="renderedContent"></div>
         
         <!-- Bottom input bar for preview mode -->
         <div v-if="showPreview" class="preview-input-bar">
@@ -91,7 +91,7 @@
             v-model="bottomInput"
             type="text"
             class="preview-input"
-            placeholder="Type a message..."
+            placeholder="Write more here..."
             @keydown.enter="handleBottomInputSend"
           />
           <button
@@ -245,7 +245,7 @@
     <GreetingSelectorModal
       v-if="showGreetingSelector"
       :story="story"
-      @close="showGreetingSelector = false"
+      @close="handleCloseGreeting"
       @select="selectGreeting"
     />
 
@@ -330,6 +330,8 @@ import { useToast } from '../composables/useToast'
 import { useNavigation } from '../composables/useNavigation'
 import { useConfirm } from '../composables/useConfirm'
 import { setPageTitle } from '../router'
+import { MARKDOWN_IMAGE_RE, MARKDOWN_IMAGE_NORMALIZE_RE, HTML_IMAGE_RE } from '../../../shared/regex-patterns.js'
+import DOMPurify from 'dompurify'
 import ReasoningPanel from '../components/ReasoningPanel.vue'
 import CharacterResponseModal from '../components/CharacterResponseModal.vue'
 import GreetingSelectorModal from '../components/GreetingSelectorModal.vue'
@@ -362,6 +364,7 @@ const story = ref(null)
 const content = ref('')
 const originalContent = ref('')
 const editorRef = ref(null)
+const previewRef = ref(null)
 const generating = ref(false)
 const generationStatus = ref('Thinking...')
 const reasoning = ref('')
@@ -405,24 +408,64 @@ const isStoryEmpty = computed(() => {
   return !content.value || content.value.trim().length === 0
 })
 
-// Computed: rendered content with markdown images converted to HTML
-const renderedContent = computed(() => {
-  if (!content.value) return ''
-  // Escape HTML special chars first
-  let html = content.value
+// Throttled rendered content — updated at most once per animation frame
+// to avoid tearing down/recreating <img> elements on every streaming token.
+function renderContent(text) {
+  if (!text) return ''
+  let html = text
+
+  // 1. Extract HTML <img> tags before escaping so they survive the pipeline
+  const savedImgs = []
+  HTML_IMAGE_RE.lastIndex = 0
+  html = html.replace(HTML_IMAGE_RE, (match) => {
+    const marker = `\x00IMG_MARKER_${savedImgs.length}\x00`
+    savedImgs.push({ marker, original: match })
+    // Inject loading=lazy and class=story-image into the saved tag
+    const enhanced = match.replace('<img', '<img loading="lazy" class="story-image"')
+    savedImgs[savedImgs.length - 1].original = enhanced
+    return marker
+  })
+
+  // 2. Escape HTML special chars including quotes (defense before markdown img injection)
+  html = html
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-  // Convert markdown images: ![alt](url) and ![alt] (url)
-  html = html.replace(/!\[([^\]]*)\]\s*\(([^)]+)\)/g, '<img src="$2" alt="$1" class="story-image" loading="lazy">')
-  // Convert double newlines to paragraphs
+    .replace(/"/g, '&quot;')
+
+  // 3. Convert markdown images: ![alt](url) and ![alt] (url)
+  MARKDOWN_IMAGE_RE.lastIndex = 0
+  html = html.replace(MARKDOWN_IMAGE_RE, '<img src="$2" alt="$1" class="story-image" loading="lazy">')
+
+  // 4. Convert double newlines to paragraphs
   html = '<p>' + html.replace(/\n\n/g, '</p><p>') + '</p>'
   // Convert single newlines to <br>
   html = html.replace(/\n/g, '<br>')
   // Remove empty paragraphs
   html = html.replace(/<p><\/p>/g, '')
+
+  // 5. Restore saved HTML <img> tags (reinserted after all transformations)
+  for (const { marker, original } of savedImgs) {
+    html = html.replace(marker, original)
+  }
+
+  // 6. Sanitize final HTML against any remaining XSS vectors (event handlers, javascript: URLs, etc.)
+  html = DOMPurify.sanitize(html)
   return html
-})
+}
+
+const renderedContent = ref('')
+let renderRAF = null
+
+function scheduleRender() {
+  if (renderRAF) return
+  renderRAF = requestAnimationFrame(() => {
+    renderRAF = null
+    renderedContent.value = renderContent(content.value)
+  })
+}
+
+watch(content, scheduleRender, { immediate: true })
 
 // Auto-save
 let autoSaveTimeout = null
@@ -442,7 +485,8 @@ function normalizeTrailingLineBreaks() {
 // Normalize markdown image syntax spacing: ![alt] (url) -> ![alt](url)
 function normalizeMarkdownImageSpacing(text) {
   if (!text) return text
-  return text.replace(/!\[([^\]]*)\]\s+\(([^)]+)\)/g, '![$1]($2)')
+  MARKDOWN_IMAGE_NORMALIZE_RE.lastIndex = 0;
+  return text.replace(MARKDOWN_IMAGE_NORMALIZE_RE, '![$1]($2)')
 }
 
 // Keyboard shortcut handler for quick paragraph generation, modal opening, and undo/redo
@@ -543,6 +587,11 @@ onUnmounted(() => {
   }
   // Remove keyboard shortcut listener
   window.removeEventListener('keydown', handleKeyboardShortcut)
+  // Cancel pending render to prevent updating after unmount
+  if (renderRAF) {
+    cancelAnimationFrame(renderRAF)
+    renderRAF = null
+  }
 })
 
 // Watch content changes for auto-save
@@ -568,6 +617,17 @@ watch(showReasoningPanel, async (isOpen) => {
       editorRef.value.scrollTop = editorRef.value.scrollHeight
       editorRef.value.focus()
     }
+  }
+})
+
+// Scroll to end when toggling preview or back to editor
+watch(showPreview, async (isPreview) => {
+  await nextTick()
+  if (isPreview && previewRef.value) {
+    previewRef.value.scrollTop = previewRef.value.scrollHeight
+  } else if (!isPreview && editorRef.value) {
+    editorRef.value.scrollTop = editorRef.value.scrollHeight
+    editorRef.value.focus()
   }
 })
 
@@ -633,12 +693,16 @@ async function saveStory(silent = false) {
   const normalizedContent = normalizeMarkdownImageSpacing(content.value)
   const normalizedOriginal = normalizeMarkdownImageSpacing(originalContent.value)
 
+  // Check if normalization changed the editor content (e.g., image spacing)
+  const wasNormalized = normalizedContent !== content.value
+
   // Keep editor content canonical when save is triggered
-  if (normalizedContent !== content.value) {
+  if (wasNormalized) {
     content.value = normalizedContent
   }
 
-  if (normalizedContent === normalizedOriginal) {
+  // Only skip save if there are no semantic changes AND no formatting normalization
+  if (!wasNormalized && normalizedContent === normalizedOriginal) {
     return // No changes
   }
 
@@ -755,7 +819,9 @@ async function handleBottomInputSend() {
   try {
     // Add user message to content with newline before and after
     const userMessage = bottomInput.value.trim()
-    content.value = content.value + '\n\n' + userMessage + '\n'
+    const trimmed = content.value.replace(/\n+$/, '')
+    content.value = trimmed + '\n\n' + userMessage + '\n\n'
+
     bottomInput.value = ''
 
     // Save the story
@@ -1051,6 +1117,19 @@ async function selectGreeting(greeting) {
   }
 }
 
+/**
+ * Called when the greeting selector is dismissed without selecting a greeting.
+ * Still shows the third-person rewrite prompt so it isn't silently skipped.
+ */
+function handleCloseGreeting() {
+  showGreetingSelector.value = false
+  nextTick().then(() => {
+    if (shouldShowThirdPersonPrompt()) {
+      showThirdPersonPrompt.value = true
+    }
+  })
+}
+
 // Handler for when user accepts the third-person prompt
 function handleThirdPersonRewrite() {
   // Call with skipConfirm=true since user already confirmed via the prompt modal
@@ -1177,6 +1256,13 @@ async function rewriteToThirdPerson(skipConfirm = false) {
     // Save
     await saveStory(true)
     toast.success('Rewrite complete')
+
+    // Scroll preview to end now that renderedContent has updated via RAF
+    await nextTick()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+    if (previewRef.value) {
+      previewRef.value.scrollTop = previewRef.value.scrollHeight
+    }
   } catch (error) {
     // Check if it was a cancellation
     if (error.name === 'AbortError' || error.message === 'Generation cancelled') {


### PR DESCRIPTION

## Changes

### 1. Image Preserver Service (new) — `server/src/services/image-preserver.js`
New service that extracts embedded images (markdown `![]()` and HTML `<img>`) from story content before sending to the LLM, replaces them with `[WG_IMAGE_X]` placeholders, and restores them after generation. Handles both `![alt](url)` and `![alt] (url)` syntax.

### 2. Image preservation integration — `server/src/routes/stories.js`
Integrated `ImagePreserver` into `streamGeneration()`:
- Extracts images before prompt building, restores after generation
- Works for streaming, polling (AI Horde), and non-streaming providers
- For `rewriteThirdPerson`: appends instruction telling LLM to preserve `[WG_IMAGE_X]` markers
- Sends `imagesRestored`, `imagesPreserved`, `imagesMissing` flags to client

### 3. Stream parser fix — `server/src/services/providers/shared/stream-parser.js`
Fixes a bug where providers that only signal completion via `[DONE]` sentinel (without a `finish_reason` chunk) would never trigger downstream finalization (image restoration). Now emits a synthetic `{ finished: true }` chunk on `[DONE]`, and also emits `finished: true` if the stream ends without an explicit finished chunk.

### 4. Language requirement — `server/src/services/default-presets.js`
Added `LANGUAGE REQUIREMENT` to system prompt: "You MUST write in the exact same language as the existing story content. Do NOT switch to English." Prevents LLM from defaulting to English when story is in another language.

### 5. Character JSON import — `server/src/routes/characters.js`
- Added `POST /characters/import-json` endpoint for importing standalone `.json` character cards
- Supports both V2 (with `data` wrapper) and flat formats
- Extracts embedded lorebooks (`character_book`) and associates with imported character
- Added `image/webp` and `image/avif` to allowed upload MIME types

### 6. Dev deps — `server/package.json`
Added `node-addon-api` and `node-gyp`.

### 7. Import modal UI — `vue_client/src/components/ImportCharacterModal.vue`
Redesigned import UI:
- **"Import from Photos"**: pick PNG/JPEG from photo gallery
- **"Import from Storage"**: browse local files, auto-detects image vs `.json`
- Added JSON file import support
- Added `charactersAPI.importJSON(file)` to `vue_client/src/services/api.js`

### 8. Preview mode — `vue_client/src/views/StoryEditor.vue`
- Added toggle button (eye icon) in header to switch between text editor and rendered preview
- `renderedContent` computed: converts markdown `![]()` to `<img>`, escapes HTML, wraps paragraphs
- Preview defaults ON if story has images (`hasImages` computed)
- `:deep()` selector used for scoped CSS on `v-html`-injected images
- Responsive image sizing: phone (≤480px), tablet (481–1024px), desktop (≥1025px)

### 9. Preview input bar — `vue_client/src/views/StoryEditor.vue`
When preview mode is on, a bottom input bar appears with text input and Send button. Typing a message and pressing Enter or clicking Send adds it to the story and triggers a character response. Includes null-guard for `editorRef` when textarea is hidden.

### 10. Image normalization — `vue_client/src/views/StoryEditor.vue`
`normalizeMarkdownImageSpacing()` normalizes `![alt] (url)` → `![alt](url)` on save to ensure consistent syntax.

### 11. Greeting selector flow — `vue_client/src/views/StoryEditor.vue`
When a new story is created with `needsRewritePrompt` flag and has characters, the greeting selector is shown FIRST (before the rewrite dialog). The rewrite dialog only appears after a greeting is selected.

### 12. Greeting selector on character detail — `vue_client/src/views/CharacterDetail.vue`
"New Story" button now shows greeting selector modal first. User selects a greeting, it's added to story, then navigates to story editor. Close without selection still navigates.

### 13. Image restoration in rewrite — `vue_client/src/views/StoryEditor.vue`
Handles server-side `imagesRestored` event in `rewriteToThirdPerson()`. When server sends back restored images via `finalContent`, the rewrite content is replaced with the server's restored version.

### 14. Viewport fix — `vue_client/src/style.css`
Added `height: 100dvh` fallback alongside `100vh` on `body`. Fixes bottom-content truncation on tablets where browser chrome occupies real viewport space.