### PR TITLE
fix: copy shared/ directory in Docker build stages - fixes issue 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM node:lts-alpine AS builder
 WORKDIR /app/vue_client
 COPY vue_client/package*.json ./
 RUN npm install
+COPY shared/ /app/shared/
 COPY vue_client/ ./
 RUN npm run build
 
@@ -25,6 +26,7 @@ RUN npm install --omit=dev
 
 # Copy server code
 COPY server/ ./
+COPY shared/ /shared/
 
 # Copy built Vue client from builder
 COPY --from=builder /app/vue_client/dist ./public/


### PR DESCRIPTION
this fixes https://github.com/amiantos/writers-guild/issues/26

The builder and production stages were missing the shared/ directory, causing ERR_MODULE_NOT_FOUND when importing regex-patterns.js.

- Builder: COPY shared/ /app/shared/ — resolves import from Vue client
- Production: COPY shared/ /shared/ — resolves import from server