### PR TITLE
Implement local image gallery for character cards and lorebooks with caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ server/public/
 AGENTS.md
 
 tasks/
+plans/

--- a/server/package.json
+++ b/server/package.json
@@ -39,5 +39,9 @@
     "pngjs": "^7.0.0",
     "supertest": "^7.1.4",
     "vitest": "^4.0.9"
+  },
+  "allowScripts": {
+    "better-sqlite3@12.10.0": true,
+    "sharp@0.34.5": true
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ import settingsRouter from './src/routes/settings.js';
 import lorebooksRouter from './src/routes/lorebooks.js';
 import presetsRouter from './src/routes/presets.js';
 import onboardingRouter from './src/routes/onboarding.js';
+import assetsRouter from './src/routes/assets.js';
 
 // Import migration service
 import { runMigration } from './src/services/migration.js';
@@ -108,6 +109,7 @@ app.use('/api/settings', settingsRouter);
 app.use('/api/lorebooks', lorebooksRouter);
 app.use('/api/presets', presetsRouter);
 app.use('/api/onboarding', onboardingRouter);
+app.use('/api/assets', assetsRouter);
 
 // Check if we're in production (built client exists)
 const publicPath = path.join(__dirname, 'public');

--- a/server/src/routes/__tests__/characters.test.js
+++ b/server/src/routes/__tests__/characters.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import fs from 'fs';
@@ -1131,6 +1131,172 @@ describe('Characters API Routes', () => {
         .expect(200);
 
       expect(dataResponse.body.character.data.mes_example).toBe('Example dialogue');
+    });
+  });
+
+  describe('POST /:characterId/refresh-images', () => {
+    let charId;
+
+    beforeEach(async () => {
+      // Create a character via POST /
+      const createResponse = await request(app)
+        .post('/api/characters')
+        .send({
+          name: 'Refresh Test',
+          description: 'Character for refresh-images test',
+        })
+        .expect(201);
+
+      charId = createResponse.body.id;
+
+      // Add external image URLs to the character data via PUT
+      await request(app)
+        .put(`/api/characters/${charId}`)
+        .send({
+          description: 'A character with an external image ![img](https://example.com/photo.png)',
+          first_mes: 'Hello! Check this out: <img src="https://example.com/banner.jpg"/>',
+        })
+        .expect(200);
+    });
+
+    it('should return success with imagesCached=0 when no images can be downloaded', async () => {
+      const response = await request(app)
+        .post(`/api/characters/${charId}/refresh-images`)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.imagesCached).toBe(0);
+      expect(response.body.message).toBe('All images already cached');
+    });
+
+    it('should return success with imagesCached>0 when new images are cached', async () => {
+      // Mock fetch to return a valid PNG so images get downloaded and cached
+      const pngBuffer = createTestPng();
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = async () => new Response(pngBuffer, {
+        status: 200,
+        headers: { 'Content-Type': 'image/png' },
+      });
+
+      try {
+        const response = await request(app)
+          .post(`/api/characters/${charId}/refresh-images`)
+          .expect(200);
+
+        expect(response.body.success).toBe(true);
+        expect(response.body.imagesCached).toBeGreaterThan(0);
+        expect(response.body.message).toContain('Cached');
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
+
+    it('should return 500 for a non-existent character', async () => {
+      await request(app)
+        .post('/api/characters/non-existent-id/refresh-images')
+        .expect(500);
+    });
+  });
+
+  describe('extractAndSaveEmbeddedLorebook error handling', () => {
+    it('should handle lorebook with no entries (empty array)', async () => {
+      const characterWithEmptyLorebook = {
+        name: 'Empty Lore',
+        description: 'Has empty lorebook',
+        character_book: {
+          name: 'Empty',
+          entries: []
+        }
+      };
+
+      const response = await request(app)
+        .post('/api/characters/import-json')
+        .attach('character', Buffer.from(JSON.stringify(characterWithEmptyLorebook)), {
+          filename: 'char.json'
+        })
+        .expect(201);
+
+      // No embedded lorebook should be created when entries are empty
+      expect(response.body.embeddedLorebook).toBeNull();
+
+      // Verify character was still created
+      expect(response.body.name).toBe('Empty Lore');
+    });
+
+    it('should handle character data with no extensions field on update-with-image', async () => {
+      // Create a character
+      const createResponse = await request(app)
+        .post('/api/characters')
+        .send({ name: 'No Ext Char' })
+        .expect(201);
+
+      const charId = createResponse.body.id;
+
+      // Update with only ursceal_lorebook_id (covers extensions init path)
+      const response = await request(app)
+        .put(`/api/characters/${charId}`)
+        .send({ ursceal_lorebook_id: 'some-lorebook-id' })
+        .expect(200);
+
+      // Verify via data endpoint
+      const dataResponse = await request(app)
+        .get(`/api/characters/${charId}/data`)
+        .expect(200);
+
+      expect(dataResponse.body.character.data.extensions.ursceal_lorebook_id).toBe('some-lorebook-id');
+    });
+  });
+
+  describe('POST /:characterId/update-with-image edge cases', () => {
+    it('should update lorebook association via update-with-image', async () => {
+      // Create a character
+      const createResponse = await request(app)
+        .post('/api/characters')
+        .send({ name: 'Lorebook Update Char' })
+        .expect(201);
+
+      const charId = createResponse.body.id;
+
+      // Update with lorebook_id (covers extensions init in update-with-image)
+      const response = await request(app)
+        .put(`/api/characters/${charId}/update-with-image`)
+        .field('characterData', JSON.stringify({
+          name: 'Lorebook Updated',
+          ursceal_lorebook_id: 'test-lorebook-id'
+        }))
+        .expect(200);
+
+      // Verify via data endpoint
+      const dataResponse = await request(app)
+        .get(`/api/characters/${charId}/data`)
+        .expect(200);
+
+      expect(dataResponse.body.character.data.extensions.ursceal_lorebook_id).toBe('test-lorebook-id');
+    });
+
+    it('should accept image with character update', async () => {
+      // Create a character
+      const createResponse = await request(app)
+        .post('/api/characters')
+        .send({ name: 'Update Img Char' })
+        .expect(201);
+
+      const charId = createResponse.body.id;
+
+      // Update with image
+      const testPng = createTestPng();
+      const response = await request(app)
+        .put(`/api/characters/${charId}/update-with-image`)
+        .field('characterData', JSON.stringify({ name: 'Updated Img', description: 'With image' }))
+        .attach('image', testPng, {
+          filename: 'avatar.png',
+          contentType: 'image/png'
+        })
+        .expect(200);
+
+      expect(response.body.name).toBe('Updated Img');
+      expect(response.body.description).toBe('With image');
+      expect(response.body.imageUrl).toContain(`/api/characters/${charId}/image`);
     });
   });
 });

--- a/server/src/routes/__tests__/lorebooks.test.js
+++ b/server/src/routes/__tests__/lorebooks.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import fs from 'fs';
@@ -472,6 +472,34 @@ describe('Lorebooks API Routes', () => {
       expect(response.body).toHaveProperty('id');
       expect(response.body.name).toBe('Imported Lorebook');
       expect(response.body.entryCount).toBe(1);
+    });
+
+    it('should cache images found in lorebook entry content', async () => {
+      const lorebookJson = {
+        entries: {
+          0: {
+            uid: 0,
+            keys: ['dragon'],
+            content: 'A dragon ![img](https://example.com/dragon.png)',
+            comment: 'See reference ![map](https://example.com/map.jpg)',
+            enabled: true,
+            order: 100
+          }
+        },
+        name: 'Cached Lorebook',
+        description: 'Lorebook with ![cover](https://example.com/cover.png)'
+      };
+
+      const response = await request(app)
+        .post('/api/lorebooks/import')
+        .attach('lorebook', Buffer.from(JSON.stringify(lorebookJson)), 'lorebook.json')
+        .expect(200);
+
+      expect(response.body.name).toBe('Cached Lorebook');
+      expect(response.body.entryCount).toBe(1);
+
+      // The caching won't persist without a successful fetch, but the
+      // code path exercises the try/catch and the empty imageMap branch
     });
   });
 

--- a/server/src/routes/assets.js
+++ b/server/src/routes/assets.js
@@ -1,0 +1,61 @@
+/**
+ * Assets API Routes
+ *
+ * Serves locally cached character gallery assets.
+ *
+ * GET /api/assets/characters/:characterId/:filename
+ *   — Serves the asset file with proper Content-Type and immutable caching.
+ */
+
+import express from 'express';
+import { asyncHandler, AppError } from '../middleware/error-handler.js';
+import { AssetManager } from '../services/asset-manager.js';
+import { mimeTypeFromExt } from '../../../shared/mime-types.js'
+import path from 'path';
+
+const router = express.Router();
+
+/**
+ * Middleware to attach an AssetManager instance per request.
+ */
+router.use((req, res, next) => {
+  req.assetManager = new AssetManager(req.app.locals.dataRoot);
+  next();
+});
+
+/**
+ * GET /api/assets/characters/:characterId/:filename
+ *
+ * Serve a cached asset file. Filename is content-hashed so we use
+ * immutable caching: files never change once created.
+ */
+router.get('/characters/:characterId/:filename', asyncHandler(async (req, res) => {
+  const { characterId, filename } = req.params;
+
+  // Basic security: prevent directory traversal in filename
+  if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+    throw new AppError('Invalid filename', 400);
+  }
+
+  // Only serve allowed image extensions
+  const ext = path.extname(filename).toLowerCase();
+  const mimeType = mimeTypeFromExt(ext);
+  if (!mimeType) {
+    throw new AppError(`Unsupported file type ${ext}`, 400);
+  }
+
+  const buffer = await req.assetManager.readAsset(characterId, filename);
+
+  if (!buffer) {
+    throw new AppError('Asset not found', 404);
+  }
+
+  // Content-hashed filenames are immutable
+  res.setHeader('Content-Type', mimeType);
+  res.setHeader('Content-Length', buffer.length);
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+
+  res.send(buffer);
+}));
+
+export default router;

--- a/server/src/routes/assets.js
+++ b/server/src/routes/assets.js
@@ -31,6 +31,20 @@ router.use((req, res, next) => {
  */
 router.get('/characters/:characterId/:filename', asyncHandler(async (req, res) => {
   const { characterId, filename } = req.params;
+  return getAsset(characterId, filename);
+}));
+
+/**
+ * GET /api/assets/lorebooks/:lorebookId/:filename
+ *
+ * Serve a cached lorebook asset file (same immutable caching strategy).
+ */
+router.get('/lorebooks/:lorebookId/:filename', asyncHandler(async (req, res) => {
+  const { lorebookId, filename } = req.params;
+  return getAsset(lorebookId, filename);
+}));
+
+const getAsset = async (assetId, filename) => {
 
   // Basic security: prevent directory traversal in filename
   if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
@@ -44,7 +58,7 @@ router.get('/characters/:characterId/:filename', asyncHandler(async (req, res) =
     throw new AppError(`Unsupported file type ${ext}`, 400);
   }
 
-  const buffer = await req.assetManager.readAsset(characterId, filename);
+  const buffer = await req.assetManager.readAsset(assetId, filename);
 
   if (!buffer) {
     throw new AppError('Asset not found', 404);
@@ -56,6 +70,6 @@ router.get('/characters/:characterId/:filename', asyncHandler(async (req, res) =
   res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
 
   res.send(buffer);
-}));
+};
 
 export default router;

--- a/server/src/routes/characters.js
+++ b/server/src/routes/characters.js
@@ -11,6 +11,8 @@ import { CharacterParser } from '../services/character-parser.js';
 import { LorebookParser } from '../services/lorebook-parser.js';
 import { ChubImporter } from '../services/chub-importer.js';
 import { IMAGE_EXTENSIONS } from '../../../shared/regex-patterns.js';
+import { cacheExternalImages, rewriteImageUrls } from '../services/image-cacher.js';
+import { AssetManager } from '../services/asset-manager.js';
 
 const router = express.Router();
 
@@ -42,6 +44,23 @@ router.use((req, res, next) => {
   }
   next();
 });
+
+/**
+ * Helper to cache external images and rewrite URLs in character card data.
+ * Does NOT throw on failure — just logs warnings so imports still succeed.
+ */
+async function cacheCardImages(characterId, cardData, dataRoot) {
+  try {
+    const imageMap = await cacheExternalImages(characterId, cardData, dataRoot);
+    if (imageMap.size > 0) {
+      rewriteImageUrls(cardData, imageMap);
+      console.log(`[cacheCardImages] Rewrote ${imageMap.size} image URL(s) for character ${characterId}`);
+    }
+  } catch (error) {
+    console.error(`[cacheCardImages] Failed to cache images for ${characterId}:`, error);
+    // Non-fatal: continue with original URLs
+  }
+}
 
 /**
  * Extract embedded lorebook from character data and save it to storage.
@@ -166,6 +185,9 @@ router.post('/import', upload.single('character'), asyncHandler(async (req, res)
   try {
     const cardData = await CharacterParser.parseCard(req.file.buffer);
 
+      // Cache external images and rewrite URLs
+      await cacheCardImages(characterId, cardData, req.app.locals.dataRoot);
+
       // Extract embedded lorebook if present
       const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
 
@@ -220,6 +242,9 @@ router.post('/', asyncHandler(async (req, res) => {
 
   // Save character (no image)
   await storage.saveCharacter(characterId, characterData, null);
+
+  // Cache any external images in the card data
+  await cacheCardImages(characterId, characterData, req.app.locals.dataRoot);
 
   res.status(201).json({
     id: characterId,
@@ -280,6 +305,9 @@ router.post('/create', upload.single('image'), asyncHandler(async (req, res) => 
   const imageBuffer = req.file ? req.file.buffer : null;
   await storage.saveCharacter(characterId, characterData, imageBuffer);
 
+  // Cache any external images in the card data
+  await cacheCardImages(characterId, characterData, req.app.locals.dataRoot);
+
   const hasImage = await storage.hasCharacterImage(characterId);
 
   res.status(201).json({
@@ -316,6 +344,9 @@ router.post('/import-json', jsonUpload.single('character'), asyncHandler(async (
   }
 
   const characterId = uuidv4();
+
+  // Cache external images and rewrite URLs
+  await cacheCardImages(characterId, cardData, req.app.locals.dataRoot);
 
   // Extract embedded lorebook if present
   const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
@@ -359,6 +390,9 @@ router.post('/import-url', asyncHandler(async (req, res) => {
       const rawCardData = await CharacterParser.parseCard(imageBuffer);
       const cardData = CharacterParser.normalizeCardData(rawCardData);
 
+      // Cache external images and rewrite URLs
+      await cacheCardImages(characterId, cardData, req.app.locals.dataRoot);
+
       // Extract embedded lorebook if present
       const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
 
@@ -389,6 +423,9 @@ router.post('/import-url', asyncHandler(async (req, res) => {
     const { characterData, imageBuffer } = await ChubImporter.importFromUrl(url);
 
     const characterId = uuidv4();
+
+    // Cache external images and rewrite URLs
+    await cacheCardImages(characterId, characterData, req.app.locals.dataRoot);
 
     // Extract embedded lorebook if present
     const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, characterData);
@@ -490,6 +527,9 @@ router.put('/:characterId', asyncHandler(async (req, res) => {
   // Save updated data (keep existing image)
   await storage.saveCharacter(characterId, existingData, null);
 
+  // Cache any new external images in the updated fields
+  await cacheCardImages(characterId, existingData, req.app.locals.dataRoot);
+
   res.json({
     id: characterId,
     name: existingData.data.name,
@@ -540,6 +580,9 @@ router.put('/:characterId/update-with-image', upload.single('image'), asyncHandl
   const imageBuffer = req.file ? req.file.buffer : null;
   await storage.saveCharacter(characterId, existingData, imageBuffer);
 
+  // Cache any new external images in the updated fields
+  await cacheCardImages(characterId, existingData, req.app.locals.dataRoot);
+
   const hasImage = await storage.hasCharacterImage(characterId);
 
   res.json({
@@ -584,7 +627,53 @@ router.delete('/:characterId', asyncHandler(async (req, res) => {
   }
 
   await storage.deleteCharacter(characterId);
+
+  // Clean up cached asset files
+  try {
+    const assetManager = new AssetManager(req.app.locals.dataRoot);
+    await assetManager.deleteDir(characterId);
+  } catch (error) {
+    console.error(`Failed to clean up assets for character ${characterId}:`, error);
+  }
+
   res.json({ success: true });
+}));
+
+/**
+ * Refresh cached external images for a character.
+ * Re-scans all text fields for external image URLs, downloads any that
+ * aren't already cached, rewrites URLs in the card data, and saves.
+ */
+router.post('/:characterId/refresh-images', asyncHandler(async (req, res) => {
+  const { characterId } = req.params;
+  const dataRoot = req.app.locals.dataRoot;
+
+  // Load existing character data
+  const cardData = await storage.getCharacter(characterId);
+
+  // Re-cache images: only new ones will be downloaded (already-cached skipped)
+  const imageMap = await cacheExternalImages(characterId, cardData, dataRoot);
+
+  if (imageMap.size > 0) {
+    // Rewrite URLs in card data for any newly cached images
+    rewriteImageUrls(cardData, imageMap);
+
+    // Persist updated card data (keep existing image blob)
+    await storage.saveCharacter(characterId, cardData, null);
+
+    res.json({
+      success: true,
+      imagesCached: imageMap.size,
+      message: `Cached ${imageMap.size} new image(s)`,
+    });
+  } else {
+    // No new images needed caching
+    res.json({
+      success: true,
+      imagesCached: 0,
+      message: 'All images already cached',
+    });
+  }
 }));
 
 export default router;

--- a/server/src/routes/characters.js
+++ b/server/src/routes/characters.js
@@ -11,7 +11,7 @@ import { CharacterParser } from '../services/character-parser.js';
 import { LorebookParser } from '../services/lorebook-parser.js';
 import { ChubImporter } from '../services/chub-importer.js';
 import { IMAGE_EXTENSIONS } from '../../../shared/regex-patterns.js';
-import { cacheExternalImages, rewriteImageUrls } from '../services/image-cacher.js';
+import { cacheCharacterImages, cacheLorebookImages, rewriteCharacterImageUrls, rewriteLorebookImageUrls } from '../services/image-cacher.js';
 import { AssetManager } from '../services/asset-manager.js';
 
 const router = express.Router();
@@ -51,9 +51,9 @@ router.use((req, res, next) => {
  */
 async function cacheCardImages(characterId, cardData, dataRoot) {
   try {
-    const imageMap = await cacheExternalImages(characterId, cardData, dataRoot);
+    const imageMap = await cacheCharacterImages(characterId, cardData, dataRoot);
     if (imageMap.size > 0) {
-      rewriteImageUrls(cardData, imageMap);
+      rewriteCharacterImageUrls(cardData, imageMap);
       console.log(`[cacheCardImages] Rewrote ${imageMap.size} image URL(s) for character ${characterId}`);
     }
   } catch (error) {
@@ -64,10 +64,11 @@ async function cacheCardImages(characterId, cardData, dataRoot) {
 
 /**
  * Extract embedded lorebook from character data and save it to storage.
+ * Also caches any external images found in the lorebook entry content.
  * Modifies cardData.data.extensions.ursceal_lorebook_id in place.
  * @returns {{ embeddedLorebook: object|null, lorebookId: string|null }}
  */
-async function extractAndSaveEmbeddedLorebook(storageInstance, cardData) {
+async function extractAndSaveEmbeddedLorebook(storageInstance, cardData, dataRoot) {
   let embeddedLorebook = null;
   let lorebookId = null;
 
@@ -83,6 +84,8 @@ async function extractAndSaveEmbeddedLorebook(storageInstance, cardData) {
       // Save to global lorebook library
       lorebookId = uuidv4();
       await storageInstance.saveLorebook(lorebookId, lorebookData);
+
+      await cacheLorebookImages(storageInstance, lorebookId, lorebookData, dataRoot);
 
       embeddedLorebook = {
         id: lorebookId,
@@ -189,7 +192,7 @@ router.post('/import', upload.single('character'), asyncHandler(async (req, res)
       await cacheCardImages(characterId, cardData, req.app.locals.dataRoot);
 
       // Extract embedded lorebook if present
-      const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
+      const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData, req.app.locals.dataRoot);
 
       // Save character data as JSON and image separately
     await storage.saveCharacter(characterId, cardData, req.file.buffer);
@@ -349,7 +352,7 @@ router.post('/import-json', jsonUpload.single('character'), asyncHandler(async (
   await cacheCardImages(characterId, cardData, req.app.locals.dataRoot);
 
   // Extract embedded lorebook if present
-  const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
+  const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData, req.app.locals.dataRoot);
 
   // Save character data (no image for JSON import)
   await storage.saveCharacter(characterId, cardData, null);
@@ -394,7 +397,7 @@ router.post('/import-url', asyncHandler(async (req, res) => {
       await cacheCardImages(characterId, cardData, req.app.locals.dataRoot);
 
       // Extract embedded lorebook if present
-      const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData);
+      const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, cardData, req.app.locals.dataRoot);
 
       // Save character data as JSON and image separately
       await storage.saveCharacter(characterId, cardData, imageBuffer);
@@ -428,7 +431,7 @@ router.post('/import-url', asyncHandler(async (req, res) => {
     await cacheCardImages(characterId, characterData, req.app.locals.dataRoot);
 
     // Extract embedded lorebook if present
-    const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, characterData);
+    const { embeddedLorebook } = await extractAndSaveEmbeddedLorebook(storage, characterData, req.app.locals.dataRoot);
 
     // Save character with image
     await storage.saveCharacter(characterId, characterData, imageBuffer);
@@ -652,11 +655,11 @@ router.post('/:characterId/refresh-images', asyncHandler(async (req, res) => {
   const cardData = await storage.getCharacter(characterId);
 
   // Re-cache images: only new ones will be downloaded (already-cached skipped)
-  const imageMap = await cacheExternalImages(characterId, cardData, dataRoot);
+  const imageMap = await cacheCharacterImages(characterId, cardData, dataRoot);
 
   if (imageMap.size > 0) {
     // Rewrite URLs in card data for any newly cached images
-    rewriteImageUrls(cardData, imageMap);
+    rewriteCharacterImageUrls(cardData, imageMap);
 
     // Persist updated card data (keep existing image blob)
     await storage.saveCharacter(characterId, cardData, null);

--- a/server/src/routes/lorebooks.js
+++ b/server/src/routes/lorebooks.js
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { asyncHandler, AppError } from '../middleware/error-handler.js';
 import { SqliteStorageService } from '../services/sqliteStorage.js';
 import { LorebookParser } from '../services/lorebook-parser.js';
+import { cacheLorebookImages, rewriteLorebookImageUrls } from '../services/image-cacher.js';
 
 const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -100,6 +101,8 @@ router.post('/import', upload.single('lorebook'), asyncHandler(async (req, res) 
     // Save to storage
     await storage.saveLorebook(lorebookId, parsed);
 
+    await cacheLorebookImages(storage, lorebookId, parsed, req.app.locals.dataRoot);
+
     res.json({
       id: lorebookId,
       name: parsed.name,
@@ -146,6 +149,8 @@ router.post('/import-url', asyncHandler(async (req, res) => {
 
     // Save to storage
     await storage.saveLorebook(lorebookId, parsed);
+
+    await cacheLorebookImages(storage, lorebookId, parsed, req.app.locals.dataRoot);
 
     res.json({
       id: lorebookId,

--- a/server/src/services/__tests__/asset-manager.test.js
+++ b/server/src/services/__tests__/asset-manager.test.js
@@ -1,0 +1,246 @@
+/**
+ * Tests for AssetManager service.
+ *
+ * Asset directories are created under:
+ *   {tempDir}/public-assets/gallery/characters/{characterId}/
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import fsSync from 'fs';
+import path from 'path';
+import os from 'os';
+import { AssetManager } from '../asset-manager.js';
+
+describe('AssetManager', () => {
+  let tempDir;
+  let assetManager;
+
+  beforeEach(() => {
+    tempDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'asset-manager-test-'));
+    assetManager = new AssetManager(tempDir);
+  });
+
+  afterEach(async () => {
+    // Clean up
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  // ── Constructor ─────────────────────────────────────────────────────
+
+  describe('constructor', () => {
+    it('should store dataRoot', () => {
+      expect(assetManager.dataRoot).toBe(tempDir);
+    });
+  });
+
+  // ── Path helpers ────────────────────────────────────────────────────
+
+  describe('characterDir', () => {
+    it('should return the correct directory path', () => {
+      const dir = assetManager.characterDir('char-123');
+      expect(dir).toBe(path.join(tempDir, 'public-assets', 'gallery', 'characters', 'char-123'));
+    });
+  });
+
+  describe('assetPath', () => {
+    it('should return the correct file path', () => {
+      const filePath = assetManager.assetPath('char-123', 'abc.png');
+      expect(filePath).toBe(
+        path.join(tempDir, 'public-assets', 'gallery', 'characters', 'char-123', 'abc.png')
+      );
+    });
+  });
+
+  describe('metadataPath', () => {
+    it('should return the metadata.json path', () => {
+      const mpath = assetManager.metadataPath('char-123');
+      expect(mpath).toBe(
+        path.join(tempDir, 'public-assets', 'gallery', 'characters', 'char-123', 'metadata.json')
+      );
+    });
+  });
+
+  // ── Directory lifecycle ─────────────────────────────────────────────
+
+  describe('ensureDir', () => {
+    it('should create the character directory recursively', async () => {
+      const dir = await assetManager.ensureDir('char-1');
+      await expect(fs.access(dir)).resolves.toBeUndefined();
+    });
+
+    it('should be idempotent (calling twice does not throw)', async () => {
+      await assetManager.ensureDir('char-1');
+      await expect(assetManager.ensureDir('char-1')).resolves.toBeDefined();
+    });
+  });
+
+  describe('deleteDir', () => {
+    it('should delete an existing character directory', async () => {
+      await assetManager.ensureDir('char-2');
+      await assetManager.deleteDir('char-2');
+
+      const dir = assetManager.characterDir('char-2');
+      await expect(fs.access(dir)).rejects.toThrow();
+    });
+
+    it('should not throw when deleting a non-existent directory', async () => {
+      await expect(assetManager.deleteDir('non-existent')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('exists', () => {
+    it('should return true when the character directory exists', async () => {
+      await assetManager.ensureDir('char-3');
+      await expect(assetManager.exists('char-3')).resolves.toBe(true);
+    });
+
+    it('should return false when the character directory does not exist', async () => {
+      await expect(assetManager.exists('non-existent')).resolves.toBe(false);
+    });
+  });
+
+  // ── Metadata operations ─────────────────────────────────────────────
+
+  describe('readMetadata', () => {
+    it('should return default metadata when no file exists', async () => {
+      const meta = await assetManager.readMetadata('no-meta-char');
+      expect(meta).toEqual({ images: [] });
+    });
+
+    it('should return previously written metadata', async () => {
+      const testMeta = { images: [{ originalUrl: 'http://example.com/img.png', hash: 'abc', filename: 'abc.png', mimeType: 'image/png' }] };
+      await assetManager.writeMetadata('meta-char', testMeta);
+
+      const meta = await assetManager.readMetadata('meta-char');
+      expect(meta).toEqual(testMeta);
+    });
+  });
+
+  describe('writeMetadata', () => {
+    it('should create the directory and write metadata.json', async () => {
+      const testMeta = { images: [] };
+      await assetManager.writeMetadata('write-char', testMeta);
+
+      const mpath = assetManager.metadataPath('write-char');
+      const raw = await fs.readFile(mpath, 'utf8');
+      expect(JSON.parse(raw)).toEqual(testMeta);
+    });
+  });
+
+  describe('addImageMetadata', () => {
+    it('should add a new image entry to metadata', async () => {
+      const entry = { originalUrl: 'http://example.com/a.png', hash: 'aaa', filename: 'aaa.png', mimeType: 'image/png' };
+      await assetManager.addImageMetadata('add-char', entry);
+
+      const meta = await assetManager.readMetadata('add-char');
+      expect(meta.images).toHaveLength(1);
+      expect(meta.images[0]).toEqual(entry);
+    });
+
+    it('should update an existing image entry with the same originalUrl', async () => {
+      const entry = { originalUrl: 'http://example.com/a.png', hash: 'aaa', filename: 'aaa.png', mimeType: 'image/png' };
+      await assetManager.addImageMetadata('update-char', entry);
+
+      const updatedEntry = { originalUrl: 'http://example.com/a.png', hash: 'bbb', filename: 'bbb.png', mimeType: 'image/webp' };
+      await assetManager.addImageMetadata('update-char', updatedEntry);
+
+      const meta = await assetManager.readMetadata('update-char');
+      expect(meta.images).toHaveLength(1);
+      expect(meta.images[0].hash).toBe('bbb');
+      expect(meta.images[0].filename).toBe('bbb.png');
+      expect(meta.images[0].mimeType).toBe('image/webp');
+    });
+
+    it('should handle multiple distinct image entries', async () => {
+      await assetManager.addImageMetadata('multi-char', { originalUrl: 'http://example.com/1.png', hash: '1', filename: '1.png', mimeType: 'image/png' });
+      await assetManager.addImageMetadata('multi-char', { originalUrl: 'http://example.com/2.png', hash: '2', filename: '2.png', mimeType: 'image/png' });
+
+      const meta = await assetManager.readMetadata('multi-char');
+      expect(meta.images).toHaveLength(2);
+    });
+  });
+
+  // ── File operations ─────────────────────────────────────────────────
+
+  describe('writeFileOnly', () => {
+    it('should write a file to the asset directory', async () => {
+      const buffer = Buffer.from('hello');
+      await assetManager.writeFileOnly('wf-char', 'test.txt', buffer);
+
+      const filePath = assetManager.assetPath('wf-char', 'test.txt');
+      const content = await fs.readFile(filePath);
+      expect(content.toString()).toBe('hello');
+    });
+
+    it('should create the directory if it does not exist', async () => {
+      const buffer = Buffer.from('data');
+      await assetManager.writeFileOnly('new-char', 'data.bin', buffer);
+
+      const dir = assetManager.characterDir('new-char');
+      await expect(fs.access(dir)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('writeAsset', () => {
+    it('should write the file and add metadata entry', async () => {
+      const buffer = Buffer.from('image data');
+      await assetManager.writeAsset('wa-char', 'abc123.png', buffer, 'http://example.com/img.png', 'image/png');
+
+      // File exists
+      const filePath = assetManager.assetPath('wa-char', 'abc123.png');
+      const content = await fs.readFile(filePath);
+      expect(content.toString()).toBe('image data');
+
+      // Metadata updated
+      const meta = await assetManager.readMetadata('wa-char');
+      expect(meta.images).toHaveLength(1);
+      expect(meta.images[0]).toMatchObject({
+        originalUrl: 'http://example.com/img.png',
+        hash: 'abc123',
+        filename: 'abc123.png',
+        mimeType: 'image/png',
+      });
+    });
+  });
+
+  describe('readAsset', () => {
+    it('should return the file buffer when it exists', async () => {
+      const buffer = Buffer.from('file content');
+      await assetManager.writeFileOnly('ra-char', 'data.txt', buffer);
+
+      const result = await assetManager.readAsset('ra-char', 'data.txt');
+      expect(result).toBeDefined();
+      expect(result.toString()).toBe('file content');
+    });
+
+    it('should return null when the file does not exist', async () => {
+      const result = await assetManager.readAsset('ra-char', 'nonexistent.txt');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listAssets', () => {
+    it('should return an empty array when no files exist', async () => {
+      const files = await assetManager.listAssets('empty-char');
+      expect(files).toEqual([]);
+    });
+
+    it('should return file names excluding metadata.json', async () => {
+      await assetManager.writeFileOnly('list-char', 'img1.png', Buffer.from('1'));
+      await assetManager.writeFileOnly('list-char', 'img2.png', Buffer.from('2'));
+      await assetManager.writeMetadata('list-char', { images: [] });
+
+      const files = await assetManager.listAssets('list-char');
+      expect(files).toEqual(expect.arrayContaining(['img1.png', 'img2.png']));
+      expect(files).not.toContain('metadata.json');
+    });
+
+    it('should return an empty array when character directory does not exist', async () => {
+      const files = await assetManager.listAssets('non-existent');
+      expect(files).toEqual([]);
+    });
+  });
+});

--- a/server/src/services/__tests__/image-cacher.test.js
+++ b/server/src/services/__tests__/image-cacher.test.js
@@ -1,0 +1,249 @@
+/**
+ * Tests for Image Cacher Service
+ *
+ * Tests URL extraction from card fields, URL rewriting, and
+ * the caching pipeline with mocked network and filesystem calls.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { cacheExternalImages, rewriteImageUrls, extractCardImageUrls } from '../image-cacher.js';
+import { AssetManager } from '../asset-manager.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeCard(fields = {}) {
+  return {
+    spec: 'chara_card_v2',
+    spec_version: '2.0',
+    data: {
+      name: 'Test',
+      description: '',
+      personality: '',
+      scenario: '',
+      first_mes: '',
+      mes_example: '',
+      creator_notes: '',
+      system_prompt: '',
+      post_history_instructions: '',
+      alternate_greetings: [],
+      ...fields,
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('extractCardImageUrls', () => {
+  it('returns empty set for card with no images', () => {
+    const card = makeCard({ description: 'plain text' });
+    expect([...extractCardImageUrls(card)]).toEqual([]);
+  });
+
+  it('extracts markdown image URLs', () => {
+    const card = makeCard({ description: '![alt](https://example.com/img.png)' });
+    const urls = extractCardImageUrls(card);
+    expect([...urls]).toEqual(['https://example.com/img.png']);
+  });
+
+  it('extracts HTML img src URLs', () => {
+    const card = makeCard({ personality: '<img src="https://host.com/avatar.jpg">' });
+    const urls = extractCardImageUrls(card);
+    expect([...urls]).toEqual(['https://host.com/avatar.jpg']);
+  });
+
+  it('extracts from all text fields', () => {
+    const card = makeCard({
+      description: '![a](https://a.com/1.png)',
+      personality: '![b](https://b.com/2.png)',
+      scenario: '<img src="https://c.com/3.jpg">',
+      first_mes: '![d](https://d.com/4.png)',
+      mes_example: '![e](https://e.com/5.png)',
+      creator_notes: '![f](https://f.com/6.png)',
+      system_prompt: '![g](https://g.com/7.png)',
+      post_history_instructions: '![h](https://h.com/8.png)',
+      alternate_greetings: ['![i](https://i.com/9.png)', '<img src="https://j.com/10.jpg">'],
+    });
+    const urls = extractCardImageUrls(card);
+    expect(urls.size).toBe(10);
+  });
+
+  it('deduplicates identical URLs across fields', () => {
+    const card = makeCard({
+      description: '![a](https://x.com/img.png)',
+      personality: '![b](https://x.com/img.png)',
+    });
+    const urls = extractCardImageUrls(card);
+    expect(urls.size).toBe(1);
+  });
+
+  it('handles null/undefined fields gracefully', () => {
+    const card = makeCard({ description: undefined, personality: null });
+    const urls = extractCardImageUrls(card);
+    expect(urls.size).toBe(0);
+  });
+});
+
+describe('rewriteImageUrls', () => {
+  it('returns cardData unchanged when imageMap is empty', () => {
+    const card = makeCard({ description: '![a](https://x.com/img.png)' });
+    const result = rewriteImageUrls(card, new Map());
+    expect(result.data.description).toBe('![a](https://x.com/img.png)');
+  });
+
+  it('rewrites markdown image URLs', () => {
+    const card = makeCard({ description: '![portrait](https://ex.com/pic.jpg)' });
+    const map = new Map([['https://ex.com/pic.jpg', '/api/assets/characters/abc/def.jpg']]);
+    rewriteImageUrls(card, map);
+    expect(card.data.description).toBe('![portrait](/api/assets/characters/abc/def.jpg)');
+  });
+
+  it('rewrites HTML img src URLs', () => {
+    const card = makeCard({ personality: '<img src="https://ex.com/ava.png">' });
+    const map = new Map([['https://ex.com/ava.png', '/api/assets/characters/xyz/aaa.png']]);
+    rewriteImageUrls(card, map);
+    expect(card.data.personality).toBe('<img src="/api/assets/characters/xyz/aaa.png">');
+  });
+
+  it('rewrites the same URL everywhere', () => {
+    const card = makeCard({
+      description: '![a](https://ex.com/img.png)',
+      personality: '![b](https://ex.com/img.png)',
+    });
+    const map = new Map([['https://ex.com/img.png', '/api/assets/abc/img.png']]);
+    rewriteImageUrls(card, map);
+    expect(card.data.description).toContain('/api/assets/abc/img.png');
+    expect(card.data.personality).toContain('/api/assets/abc/img.png');
+  });
+
+  it('rewrites URLs in alternate greetings', () => {
+    const card = makeCard({
+      alternate_greetings: ['Hello ![img](https://ex.com/greet1.png)'],
+    });
+    const map = new Map([['https://ex.com/greet1.png', '/api/assets/abc/g1.png']]);
+    rewriteImageUrls(card, map);
+    expect(card.data.alternate_greetings[0]).toContain('/api/assets/abc/g1.png');
+  });
+
+  it('handles URLs with special regex characters', () => {
+    const card = makeCard({ description: '![a](https://ex.com/pic+(1).jpg)' });
+    const map = new Map([['https://ex.com/pic+(1).jpg', '/api/assets/abc/pic.jpg']]);
+    rewriteImageUrls(card, map);
+    expect(card.data.description).toBe('![a](/api/assets/abc/pic.jpg)');
+  });
+
+  it('returns early when cardData has no data sub-object', () => {
+    const card = { spec: 'v2' };
+    const result = rewriteImageUrls(card, new Map([['x', 'y']]));
+    expect(result).toBe(card);
+  });
+});
+
+describe('cacheExternalImages (mocked fetch + fs)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.spyOn(AssetManager.prototype, 'readMetadata').mockResolvedValue({ images: [] });
+    vi.spyOn(AssetManager.prototype, 'ensureDir').mockResolvedValue('/fake/dir');
+    vi.spyOn(AssetManager.prototype, 'writeFileOnly').mockResolvedValue(undefined);
+    vi.spyOn(AssetManager.prototype, 'writeMetadata').mockResolvedValue(undefined);
+    vi.spyOn(AssetManager.prototype, 'assetPath').mockReturnValue('/fake/file.png');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty map when card has no images', async () => {
+    const card = makeCard({ description: 'no images' });
+    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    expect(result.size).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('downloads and caches a single markdown image', async () => {
+    const pngBuffer = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0]);
+    fetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'image/png' },
+      body: {
+        getReader() {
+          let done = false;
+          return {
+            read() {
+              if (done) return Promise.resolve({ done: true });
+              done = true;
+              return Promise.resolve({
+                done: false,
+                value: new Uint8Array(pngBuffer),
+              });
+            },
+            cancel() {},
+          };
+        },
+      },
+    });
+
+    const card = makeCard({ description: '![x](https://remote.com/pic.png)' });
+    const result = await cacheExternalImages('char-1', card, '/fake/data');
+
+    expect(result.size).toBe(1);
+    const localUrl = result.get('https://remote.com/pic.png');
+    expect(localUrl).toMatch(/^\/api\/assets\/characters\/char-1\/[a-f0-9]+\.png$/);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(AssetManager.prototype.writeMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips already-cached images', async () => {
+    vi.spyOn(AssetManager.prototype, 'readMetadata').mockResolvedValue({
+      images: [{ originalUrl: 'https://remote.com/pic.png', hash: 'abc', filename: 'abc.png' }],
+    });
+
+    const card = makeCard({ description: '![x](https://remote.com/pic.png)' });
+    const result = await cacheExternalImages('char-1', card, '/fake/data');
+
+    expect(result.size).toBe(1);
+    expect(result.get('https://remote.com/pic.png')).toBe('/api/assets/characters/char-1/abc.png');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fail on download errors', async () => {
+    fetch.mockRejectedValue(new Error('Network error'));
+    const card = makeCard({ description: '![x](https://remote.com/pic.png)' });
+    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    expect(result.size).toBe(0);
+  });
+
+  it('handles non-image Content-Type gracefully', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'text/html' },
+      body: {
+        getReader() {
+          let done = false;
+          return {
+            read() {
+              if (done) return Promise.resolve({ done: true });
+              done = true;
+              return Promise.resolve({ done: false, value: new Uint8Array(Buffer.from('x')) });
+            },
+            cancel() {},
+          };
+        },
+      },
+    });
+    const card = makeCard({ description: '![x](https://remote.com/not-img)' });
+    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    expect(result.size).toBe(0);
+  });
+});
+
+describe('AssetManager (interface)', () => {
+  it('provides all expected methods', () => {
+    expect(typeof AssetManager.prototype.ensureDir).toBe('function');
+    expect(typeof AssetManager.prototype.writeAsset).toBe('function');
+    expect(typeof AssetManager.prototype.readAsset).toBe('function');
+    expect(typeof AssetManager.prototype.deleteDir).toBe('function');
+    expect(typeof AssetManager.prototype.readMetadata).toBe('function');
+    expect(typeof AssetManager.prototype.writeMetadata).toBe('function');
+  });
+});

--- a/server/src/services/__tests__/image-cacher.test.js
+++ b/server/src/services/__tests__/image-cacher.test.js
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { cacheExternalImages, rewriteImageUrls, extractCardImageUrls } from '../image-cacher.js';
+import { cacheCharacterImages, cacheLorebookImages, rewriteCharacterImageUrls, rewriteLorebookImageUrls, extractCardImageUrls, extractLorebookImageUrls } from '../image-cacher.js';
 import { AssetManager } from '../asset-manager.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -83,24 +83,24 @@ describe('extractCardImageUrls', () => {
   });
 });
 
-describe('rewriteImageUrls', () => {
+describe('rewriteCharacterImageUrls', () => {
   it('returns cardData unchanged when imageMap is empty', () => {
     const card = makeCard({ description: '![a](https://x.com/img.png)' });
-    const result = rewriteImageUrls(card, new Map());
+    const result = rewriteCharacterImageUrls(card, new Map());
     expect(result.data.description).toBe('![a](https://x.com/img.png)');
   });
 
   it('rewrites markdown image URLs', () => {
     const card = makeCard({ description: '![portrait](https://ex.com/pic.jpg)' });
     const map = new Map([['https://ex.com/pic.jpg', '/api/assets/characters/abc/def.jpg']]);
-    rewriteImageUrls(card, map);
+    rewriteCharacterImageUrls(card, map);
     expect(card.data.description).toBe('![portrait](/api/assets/characters/abc/def.jpg)');
   });
 
   it('rewrites HTML img src URLs', () => {
     const card = makeCard({ personality: '<img src="https://ex.com/ava.png">' });
     const map = new Map([['https://ex.com/ava.png', '/api/assets/characters/xyz/aaa.png']]);
-    rewriteImageUrls(card, map);
+    rewriteCharacterImageUrls(card, map);
     expect(card.data.personality).toBe('<img src="/api/assets/characters/xyz/aaa.png">');
   });
 
@@ -110,7 +110,7 @@ describe('rewriteImageUrls', () => {
       personality: '![b](https://ex.com/img.png)',
     });
     const map = new Map([['https://ex.com/img.png', '/api/assets/abc/img.png']]);
-    rewriteImageUrls(card, map);
+    rewriteCharacterImageUrls(card, map);
     expect(card.data.description).toContain('/api/assets/abc/img.png');
     expect(card.data.personality).toContain('/api/assets/abc/img.png');
   });
@@ -120,25 +120,233 @@ describe('rewriteImageUrls', () => {
       alternate_greetings: ['Hello ![img](https://ex.com/greet1.png)'],
     });
     const map = new Map([['https://ex.com/greet1.png', '/api/assets/abc/g1.png']]);
-    rewriteImageUrls(card, map);
+    rewriteCharacterImageUrls(card, map);
     expect(card.data.alternate_greetings[0]).toContain('/api/assets/abc/g1.png');
   });
 
   it('handles URLs with special regex characters', () => {
     const card = makeCard({ description: '![a](https://ex.com/pic+(1).jpg)' });
     const map = new Map([['https://ex.com/pic+(1).jpg', '/api/assets/abc/pic.jpg']]);
-    rewriteImageUrls(card, map);
+    rewriteCharacterImageUrls(card, map);
     expect(card.data.description).toBe('![a](/api/assets/abc/pic.jpg)');
   });
 
   it('returns early when cardData has no data sub-object', () => {
     const card = { spec: 'v2' };
-    const result = rewriteImageUrls(card, new Map([['x', 'y']]));
+    const result = rewriteCharacterImageUrls(card, new Map([['x', 'y']]));
     expect(result).toBe(card);
   });
 });
 
-describe('cacheExternalImages (mocked fetch + fs)', () => {
+describe('extractLorebookImageUrls', () => {
+  function makeLorebook(entries = [], description = '') {
+    return {
+      name: 'Test Lorebook',
+      description,
+      entries,
+    };
+  }
+
+  it('returns empty set for lorebook with no images', () => {
+    const lorebook = makeLorebook([{ content: 'plain text' }]);
+    expect([...extractLorebookImageUrls(lorebook)]).toEqual([]);
+  });
+
+  it('extracts markdown image URLs from entry content', () => {
+    const lorebook = makeLorebook([
+      { content: '![dragon](https://ex.com/dragon.png)' },
+    ]);
+    const urls = extractLorebookImageUrls(lorebook);
+    expect([...urls]).toEqual(['https://ex.com/dragon.png']);
+  });
+
+  it('extracts HTML img src URLs from entry content', () => {
+    const lorebook = makeLorebook([
+      { content: '<img src="https://host.com/creature.jpg">' },
+    ]);
+    const urls = extractLorebookImageUrls(lorebook);
+    expect([...urls]).toEqual(['https://host.com/creature.jpg']);
+  });
+
+  it('extracts URLs from entry comment fields', () => {
+    const lorebook = makeLorebook([
+      {
+        content: 'just text',
+        comment: 'see ![map](https://ex.com/map.png)',
+      },
+    ]);
+    const urls = extractLorebookImageUrls(lorebook);
+    expect([...urls]).toEqual(['https://ex.com/map.png']);
+  });
+
+  it('extracts URLs from lorebook description', () => {
+    const lorebook = makeLorebook([], 'Cover image: ![cover](https://ex.com/cover.jpg)');
+    const urls = extractLorebookImageUrls(lorebook);
+    expect([...urls]).toEqual(['https://ex.com/cover.jpg']);
+  });
+
+  it('extracts from multiple entries and deduplicates', () => {
+    const lorebook = makeLorebook([
+      { content: '![a](https://ex.com/img.png)' },
+      { content: '![b](https://ex.com/img.png)' },
+      { content: '![c](https://ex.com/other.png)' },
+    ]);
+    const urls = extractLorebookImageUrls(lorebook);
+    expect(urls.size).toBe(2);
+  });
+
+  it('handles lorebook with no entries', () => {
+    const lorebook = makeLorebook([]);
+    expect([...extractLorebookImageUrls(lorebook)]).toEqual([]);
+  });
+
+  it('handles null/undefined lorebook gracefully', () => {
+    expect([...extractLorebookImageUrls(null)]).toEqual([]);
+    expect([...extractLorebookImageUrls(undefined)]).toEqual([]);
+  });
+});
+
+describe('rewriteLorebookImageUrls', () => {
+  function makeLorebook(entries = [], description = '') {
+    return {
+      name: 'Test Lorebook',
+      description,
+      entries,
+    };
+  }
+
+  it('returns lorebookData unchanged when imageMap is empty', () => {
+    const lorebook = makeLorebook([{ content: '![a](https://x.com/img.png)' }]);
+    const result = rewriteLorebookImageUrls(lorebook, new Map());
+    expect(result.entries[0].content).toBe('![a](https://x.com/img.png)');
+  });
+
+  it('rewrites URLs in entry content', () => {
+    const lorebook = makeLorebook([
+      { content: '![dragon](https://ex.com/dragon.png)' },
+    ]);
+    const map = new Map([['https://ex.com/dragon.png', '/api/assets/lorebooks/abc/def.webp']]);
+    rewriteLorebookImageUrls(lorebook, map);
+    expect(lorebook.entries[0].content).toBe('![dragon](/api/assets/lorebooks/abc/def.webp)');
+  });
+
+  it('rewrites URLs in entry comment', () => {
+    const lorebook = makeLorebook([
+      {
+        content: 'plain',
+        comment: 'see ![map](https://ex.com/map.png)',
+      },
+    ]);
+    const map = new Map([['https://ex.com/map.png', '/api/assets/lorebooks/x/y.webp']]);
+    rewriteLorebookImageUrls(lorebook, map);
+    expect(lorebook.entries[0].comment).toContain('/api/assets/lorebooks/x/y.webp');
+  });
+
+  it('rewrites URLs in lorebook description', () => {
+    const lorebook = makeLorebook([{ content: 'text' }], 'Cover: ![c](https://ex.com/cover.jpg)');
+    const map = new Map([['https://ex.com/cover.jpg', '/api/assets/lorebooks/z/cover.webp']]);
+    rewriteLorebookImageUrls(lorebook, map);
+    expect(lorebook.description).toContain('/api/assets/lorebooks/z/cover.webp');
+  });
+
+  it('returns early when lorebookData has no entries', () => {
+    const lorebook = { name: 'Empty' };
+    const result = rewriteLorebookImageUrls(lorebook, new Map([['x', 'y']]));
+    expect(result).toBe(lorebook);
+  });
+});
+
+describe('cacheLorebookImages (mocked fetch + fs)', () => {
+  let mockStorage;
+
+  beforeEach(() => {
+    mockStorage = { saveLorebook: vi.fn().mockResolvedValue({}) };
+    vi.stubGlobal('fetch', vi.fn());
+    vi.spyOn(AssetManager.prototype, 'readMetadata').mockResolvedValue({ images: [] });
+    vi.spyOn(AssetManager.prototype, 'ensureDir').mockResolvedValue('/fake/dir');
+    vi.spyOn(AssetManager.prototype, 'writeFileOnly').mockResolvedValue(undefined);
+    vi.spyOn(AssetManager.prototype, 'writeMetadata').mockResolvedValue(undefined);
+    vi.spyOn(AssetManager.prototype, 'assetPath').mockReturnValue('/fake/file.png');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when lorebook has no images', async () => {
+    const lorebook = { name: 'Empty', entries: [{ content: 'no images' }] };
+    const result = await cacheLorebookImages(mockStorage, 'lb-1', lorebook, '/fake/data');
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('downloads and caches images from entry content', async () => {
+    const pngBuffer = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 0]);
+    fetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'image/png' },
+      body: {
+        getReader() {
+          let done = false;
+          return {
+            read() {
+              if (done) return Promise.resolve({ done: true });
+              done = true;
+              return Promise.resolve({ done: false, value: new Uint8Array(pngBuffer) });
+            },
+            cancel() {},
+          };
+        },
+      },
+    });
+
+    const lorebook = {
+      name: 'Test Lorebook',
+      entries: [
+        { content: '![dragon](https://remote.com/dragon.png)' },
+      ],
+    };
+    const result = await cacheLorebookImages(mockStorage, 'lb-1', lorebook, '/fake/data');
+
+    expect(result.size).toBe(1);
+    const localUrl = result.get('https://remote.com/dragon.png');
+    expect(localUrl).toMatch(/^\/api\/assets\/lorebooks\/lb-1\/[a-f0-9]+\.png$/);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // Should have rewritten URL in the lorebook data and saved
+    expect(lorebook.entries[0].content).toContain('/api/assets/lorebooks/lb-1/');
+    expect(mockStorage.saveLorebook).toHaveBeenCalledOnce();
+  });
+
+  it('skips already-cached images', async () => {
+    vi.spyOn(AssetManager.prototype, 'readMetadata').mockResolvedValue({
+      images: [{ originalUrl: 'https://remote.com/dragon.png', hash: 'abc', filename: 'abc.png' }],
+    });
+
+    const lorebook = {
+      name: 'Cached Lorebook',
+      entries: [{ content: '![x](https://remote.com/dragon.png)' }],
+    };
+    const result = await cacheLorebookImages(mockStorage, 'lb-1', lorebook, '/fake/data');
+    expect(result.size).toBe(1);
+    expect(result.get('https://remote.com/dragon.png')).toBe('/api/assets/lorebooks/lb-1/abc.png');
+    expect(fetch).not.toHaveBeenCalled();
+    // Already-cached also triggers rewrite + save
+    expect(mockStorage.saveLorebook).toHaveBeenCalledOnce();
+  });
+
+  it('does not fail on download errors', async () => {
+    fetch.mockRejectedValue(new Error('Network error'));
+    const lorebook = {
+      name: 'Fail Lorebook',
+      entries: [{ content: '![x](https://remote.com/pic.png)' }],
+    };
+    const result = await cacheLorebookImages(mockStorage, 'lb-1', lorebook, '/fake/data');
+    expect(result).toBeNull();
+  });
+});
+
+describe('cacheCharacterImages (mocked fetch + fs)', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
     vi.spyOn(AssetManager.prototype, 'readMetadata').mockResolvedValue({ images: [] });
@@ -155,7 +363,7 @@ describe('cacheExternalImages (mocked fetch + fs)', () => {
 
   it('returns empty map when card has no images', async () => {
     const card = makeCard({ description: 'no images' });
-    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
     expect(result.size).toBe(0);
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -184,7 +392,7 @@ describe('cacheExternalImages (mocked fetch + fs)', () => {
     });
 
     const card = makeCard({ description: '![x](https://remote.com/pic.png)' });
-    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
 
     expect(result.size).toBe(1);
     const localUrl = result.get('https://remote.com/pic.png');
@@ -199,7 +407,7 @@ describe('cacheExternalImages (mocked fetch + fs)', () => {
     });
 
     const card = makeCard({ description: '![x](https://remote.com/pic.png)' });
-    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
 
     expect(result.size).toBe(1);
     expect(result.get('https://remote.com/pic.png')).toBe('/api/assets/characters/char-1/abc.png');
@@ -209,7 +417,7 @@ describe('cacheExternalImages (mocked fetch + fs)', () => {
   it('does not fail on download errors', async () => {
     fetch.mockRejectedValue(new Error('Network error'));
     const card = makeCard({ description: '![x](https://remote.com/pic.png)' });
-    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
     expect(result.size).toBe(0);
   });
 
@@ -232,8 +440,29 @@ describe('cacheExternalImages (mocked fetch + fs)', () => {
       },
     });
     const card = makeCard({ description: '![x](https://remote.com/not-img)' });
-    const result = await cacheExternalImages('char-1', card, '/fake/data');
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
     expect(result.size).toBe(0);
+  });
+
+  it('rejects non-HTTP URLs', async () => {
+    const card = makeCard({ description: '![x](ftp://example.com/img.png)' });
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
+    expect(result.size).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed URLs', async () => {
+    const card = makeCard({ description: '![x](not a url)' });
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
+    expect(result.size).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty or null URLs', async () => {
+    const card = makeCard({ description: '![](  )' });
+    const result = await cacheCharacterImages('char-1', card, '/fake/data');
+    expect(result.size).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/server/src/services/asset-manager.js
+++ b/server/src/services/asset-manager.js
@@ -1,8 +1,8 @@
 /**
  * Asset Manager Service
  *
- * Manages per-character asset directories under:
- *   {dataRoot}/public-assets/gallery/characters/{characterId}/
+ * Manages per-entity asset directories under:
+ *   {dataRoot}/public-assets/gallery/{entityType}/{entityId}/
  *
  * Each directory contains:
  *   - {hash}.{ext}         — downloaded image files named by content hash
@@ -12,40 +12,48 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-const ASSETS_BASE = ['public-assets', 'gallery', 'characters'];
+const ASSETS_BASE = ['public-assets', 'gallery'];
 
 export class AssetManager {
   /**
-   * @param {string} dataRoot  — resolved data root path (e.g. ../data)
+   * @param {string} dataRoot    — resolved data root path (e.g. ../data)
+   * @param {string} [entityType] — subdirectory under gallery, e.g. 'characters' or 'lorebooks' (default 'characters')
    */
-  constructor(dataRoot) {
+  constructor(dataRoot, entityType = 'characters') {
     this.dataRoot = dataRoot;
+    this.entityType = entityType;
   }
 
   // ── Path helpers ────────────────────────────────────────────────────
 
+  entityDir(entityId) {
+    return path.join(this.dataRoot, ...ASSETS_BASE, this.entityType, entityId);
+  }
+
+  assetPath(entityId, filename) {
+    return path.join(this.entityDir(entityId), filename);
+  }
+
+  metadataPath(entityId) {
+    return path.join(this.entityDir(entityId), 'metadata.json');
+  }
+
+  // ── Backward-compatible aliases ─────────────────────────────────────
+
   characterDir(characterId) {
-    return path.join(this.dataRoot, ...ASSETS_BASE, characterId);
-  }
-
-  assetPath(characterId, filename) {
-    return path.join(this.characterDir(characterId), filename);
-  }
-
-  metadataPath(characterId) {
-    return path.join(this.characterDir(characterId), 'metadata.json');
+    return this.entityDir(characterId);
   }
 
   // ── Directory lifecycle ─────────────────────────────────────────────
 
-  async ensureDir(characterId) {
-    const dir = this.characterDir(characterId);
+  async ensureDir(entityId) {
+    const dir = this.entityDir(entityId);
     await fs.mkdir(dir, { recursive: true });
     return dir;
   }
 
-  async deleteDir(characterId) {
-    const dir = this.characterDir(characterId);
+  async deleteDir(entityId) {
+    const dir = this.entityDir(entityId);
     try {
       await fs.rm(dir, { recursive: true, force: true });
     } catch (err) {
@@ -53,8 +61,8 @@ export class AssetManager {
     }
   }
 
-  async exists(characterId) {
-    const dir = this.characterDir(characterId);
+  async exists(entityId) {
+    const dir = this.entityDir(entityId);
     try {
       await fs.access(dir);
       return true;
@@ -65,8 +73,8 @@ export class AssetManager {
 
   // ── Metadata ────────────────────────────────────────────────────────
 
-  async readMetadata(characterId) {
-    const mpath = this.metadataPath(characterId);
+  async readMetadata(entityId) {
+    const mpath = this.metadataPath(entityId);
     try {
       const raw = await fs.readFile(mpath, 'utf8');
       return JSON.parse(raw);
@@ -75,21 +83,21 @@ export class AssetManager {
     }
   }
 
-  async writeMetadata(characterId, metadata) {
-    const mpath = this.metadataPath(characterId);
-    await this.ensureDir(characterId);
+  async writeMetadata(entityId, metadata) {
+    const mpath = this.metadataPath(entityId);
+    await this.ensureDir(entityId);
     await fs.writeFile(mpath, JSON.stringify(metadata, null, 2), 'utf8');
   }
 
-  async addImageMetadata(characterId, entry) {
-    const meta = await this.readMetadata(characterId);
+  async addImageMetadata(entityId, entry) {
+    const meta = await this.readMetadata(entityId);
     const existing = meta.images.find(i => i.originalUrl === entry.originalUrl);
     if (existing) {
       Object.assign(existing, entry);
     } else {
       meta.images.push(entry);
     }
-    await this.writeMetadata(characterId, meta);
+    await this.writeMetadata(entityId, meta);
   }
 
   // ── File operations ─────────────────────────────────────────────────
@@ -98,9 +106,9 @@ export class AssetManager {
    * Write a file and update metadata.json.
    * Safe for single writes; for bulk writes use writeFileOnly() + writeMetadata().
    */
-  async writeAsset(characterId, filename, buffer, originalUrl, mimeType) {
-    await this.writeFileOnly(characterId, filename, buffer);
-    await this.addImageMetadata(characterId, {
+  async writeAsset(entityId, filename, buffer, originalUrl, mimeType) {
+    await this.writeFileOnly(entityId, filename, buffer);
+    await this.addImageMetadata(entityId, {
       originalUrl,
       hash: path.parse(filename).name,
       filename,
@@ -112,14 +120,14 @@ export class AssetManager {
    * Write a file to the asset directory without touching metadata.
    * Useful when bulk-writing files before a single metadata write.
    */
-  async writeFileOnly(characterId, filename, buffer) {
-    await this.ensureDir(characterId);
-    const filePath = this.assetPath(characterId, filename);
+  async writeFileOnly(entityId, filename, buffer) {
+    await this.ensureDir(entityId);
+    const filePath = this.assetPath(entityId, filename);
     await fs.writeFile(filePath, buffer);
   }
 
-  async readAsset(characterId, filename) {
-    const filePath = this.assetPath(characterId, filename);
+  async readAsset(entityId, filename) {
+    const filePath = this.assetPath(entityId, filename);
     try {
       return await fs.readFile(filePath);
     } catch {
@@ -127,8 +135,8 @@ export class AssetManager {
     }
   }
 
-  async listAssets(characterId) {
-    const dir = this.characterDir(characterId);
+  async listAssets(entityId) {
+    const dir = this.entityDir(entityId);
     try {
       const entries = await fs.readdir(dir, { withFileTypes: true });
       return entries.filter(e => e.isFile() && e.name !== 'metadata.json').map(e => e.name);

--- a/server/src/services/asset-manager.js
+++ b/server/src/services/asset-manager.js
@@ -1,0 +1,139 @@
+/**
+ * Asset Manager Service
+ *
+ * Manages per-character asset directories under:
+ *   {dataRoot}/public-assets/gallery/characters/{characterId}/
+ *
+ * Each directory contains:
+ *   - {hash}.{ext}         — downloaded image files named by content hash
+ *   - metadata.json        — mapping of original URLs → hash → filename
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+
+const ASSETS_BASE = ['public-assets', 'gallery', 'characters'];
+
+export class AssetManager {
+  /**
+   * @param {string} dataRoot  — resolved data root path (e.g. ../data)
+   */
+  constructor(dataRoot) {
+    this.dataRoot = dataRoot;
+  }
+
+  // ── Path helpers ────────────────────────────────────────────────────
+
+  characterDir(characterId) {
+    return path.join(this.dataRoot, ...ASSETS_BASE, characterId);
+  }
+
+  assetPath(characterId, filename) {
+    return path.join(this.characterDir(characterId), filename);
+  }
+
+  metadataPath(characterId) {
+    return path.join(this.characterDir(characterId), 'metadata.json');
+  }
+
+  // ── Directory lifecycle ─────────────────────────────────────────────
+
+  async ensureDir(characterId) {
+    const dir = this.characterDir(characterId);
+    await fs.mkdir(dir, { recursive: true });
+    return dir;
+  }
+
+  async deleteDir(characterId) {
+    const dir = this.characterDir(characterId);
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+  }
+
+  async exists(characterId) {
+    const dir = this.characterDir(characterId);
+    try {
+      await fs.access(dir);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ── Metadata ────────────────────────────────────────────────────────
+
+  async readMetadata(characterId) {
+    const mpath = this.metadataPath(characterId);
+    try {
+      const raw = await fs.readFile(mpath, 'utf8');
+      return JSON.parse(raw);
+    } catch {
+      return { images: [] };
+    }
+  }
+
+  async writeMetadata(characterId, metadata) {
+    const mpath = this.metadataPath(characterId);
+    await this.ensureDir(characterId);
+    await fs.writeFile(mpath, JSON.stringify(metadata, null, 2), 'utf8');
+  }
+
+  async addImageMetadata(characterId, entry) {
+    const meta = await this.readMetadata(characterId);
+    const existing = meta.images.find(i => i.originalUrl === entry.originalUrl);
+    if (existing) {
+      Object.assign(existing, entry);
+    } else {
+      meta.images.push(entry);
+    }
+    await this.writeMetadata(characterId, meta);
+  }
+
+  // ── File operations ─────────────────────────────────────────────────
+
+  /**
+   * Write a file and update metadata.json.
+   * Safe for single writes; for bulk writes use writeFileOnly() + writeMetadata().
+   */
+  async writeAsset(characterId, filename, buffer, originalUrl, mimeType) {
+    await this.writeFileOnly(characterId, filename, buffer);
+    await this.addImageMetadata(characterId, {
+      originalUrl,
+      hash: path.parse(filename).name,
+      filename,
+      mimeType,
+    });
+  }
+
+  /**
+   * Write a file to the asset directory without touching metadata.
+   * Useful when bulk-writing files before a single metadata write.
+   */
+  async writeFileOnly(characterId, filename, buffer) {
+    await this.ensureDir(characterId);
+    const filePath = this.assetPath(characterId, filename);
+    await fs.writeFile(filePath, buffer);
+  }
+
+  async readAsset(characterId, filename) {
+    const filePath = this.assetPath(characterId, filename);
+    try {
+      return await fs.readFile(filePath);
+    } catch {
+      return null;
+    }
+  }
+
+  async listAssets(characterId) {
+    const dir = this.characterDir(characterId);
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      return entries.filter(e => e.isFile() && e.name !== 'metadata.json').map(e => e.name);
+    } catch {
+      return [];
+    }
+  }
+}

--- a/server/src/services/image-cacher.js
+++ b/server/src/services/image-cacher.js
@@ -1,0 +1,326 @@
+/**
+ * Image Cacher Service
+ *
+ * Scans character card text fields for external image URLs (Markdown and HTML),
+ * downloads them, stores them locally via AssetManager with content-hash filenames,
+ * and rewrites the card data to reference the local paths.
+ *
+ * Used during character import/create/update to build a local gallery.
+ */
+
+import crypto from 'crypto';
+import sharp from 'sharp';
+import { AssetManager } from './asset-manager.js';
+import { MARKDOWN_IMAGE_RE, HTML_IMAGE_RE } from '../../../shared/regex-patterns.js';
+import { IMAGE_MIME_TYPES_MAP, mimeTypeToExt } from '../../../shared/mime-types.js'
+
+// ── Configuration ─────────────────────────────────────────────────────
+
+const DOWNLOAD_TIMEOUT_MS = 15_000;       // 15 s per image
+const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_CONCURRENT_DOWNLOADS = 3;
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Compute SHA-256 hex digest of a buffer.
+ */
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+/**
+ * Extract all image URLs (Markdown and HTML) from a single text string.
+ * Returns a Set of unique URLs.
+ *
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+function extractImageUrls(text) {
+  const urls = new Set();
+
+  if (!text || typeof text !== 'string') return urls;
+
+  // Markdown: ![alt](url)
+  let m;
+  MARKDOWN_IMAGE_RE.lastIndex = 0;
+  while ((m = MARKDOWN_IMAGE_RE.exec(text)) !== null) {
+    urls.add(m[2]); // capture group 2 is the URL
+  }
+
+  // HTML: <img src="..." ...>
+  HTML_IMAGE_RE.lastIndex = 0;
+  while ((m = HTML_IMAGE_RE.exec(text)) !== null) {
+    const tag = m[0];
+    // Extract src attribute
+    const srcMatch = tag.match(/src\s*=\s*["']([^"']+)["']/i);
+    if (srcMatch) {
+      urls.add(srcMatch[1]);
+    }
+  }
+
+  return urls;
+}
+
+/**
+ * Collect all image URLs from every text field of a character card.
+ *
+ * @param {object} cardData  — normalized V2 card data (has .data sub-object)
+ * @returns {Set<string>}
+ */
+function collectAllImageUrls(cardData) {
+  const data = cardData?.data;
+  if (!data) return new Set();
+
+  const fields = [
+    data.description,
+    data.personality,
+    data.scenario,
+    data.first_mes,
+    data.mes_example,
+    data.creator_notes,
+    data.system_prompt,
+    data.post_history_instructions,
+    ...(Array.isArray(data.alternate_greetings) ? data.alternate_greetings : []),
+  ];
+
+  const all = new Set();
+  for (const field of fields) {
+    for (const url of extractImageUrls(field)) {
+      all.add(url);
+    }
+  }
+  return all;
+}
+
+/**
+ * Download a single image from a URL.
+ *
+ * @param {string} url
+ * @returns {Promise<{ buffer: Buffer, mimeType: string } | null>}
+ *   Returns null if the download fails or the content is not a valid image.
+ */
+async function downloadImage(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; WritersGuild/2.0)',
+        'Accept': 'image/*',
+      },
+    });
+
+    if (!response.ok) {
+      console.warn(`[ImageCacher] Download failed (${response.status}): ${url}`);
+      return null;
+    }
+
+    // Validate Content-Type
+    const contentType = response.headers.get('content-type') || '';
+    const mimeType = contentType.split(';')[0].trim().toLowerCase();
+    
+    if (!IMAGE_MIME_TYPES_MAP[mimeType]) {
+      console.warn(`[ImageCacher] Skipping non-image Content-Type "${mimeType}": ${url}`);
+      return null;
+    }
+
+    // Read body with size limit
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > MAX_IMAGE_SIZE_BYTES) {
+        console.warn(`[ImageCacher] Image too large (>${MAX_IMAGE_SIZE_BYTES} bytes): ${url}`);
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+
+    const buffer = Buffer.concat(chunks);
+    return { buffer, mimeType };
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      console.warn(`[ImageCacher] Timeout downloading: ${url}`);
+    } else {
+      console.warn(`[ImageCacher] Error downloading ${url}: ${err.message}`);
+    }
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Download all external images referenced in a character card, store them
+ * locally via AssetManager, and return a mapping of original URL → local path.
+ *
+ * Only downloads images that are not already cached (by checking metadata).
+ * Does NOT modify cardData — call rewriteImageUrls() separately.
+ *
+ * @param {string}   characterId
+ * @param {object}   cardData   — normalized V2 card data
+ * @param {string}   dataRoot   — resolved data root path
+ * @param {object}   [options]
+ * @param {number}   [options.concurrency]  — max parallel downloads (default 3)
+ * @returns {Promise<Map<string, string>>}
+ *   Map where key = original URL, value = local path (e.g. "/api/assets/characters/{id}/{hash}.jpg")
+ */
+export async function cacheExternalImages(characterId, cardData, dataRoot, options = {}) {
+  const assetManager = new AssetManager(dataRoot);
+  const concurrency = options.concurrency ?? MAX_CONCURRENT_DOWNLOADS;
+
+  // Collect all unique image URLs from the card
+  const urls = collectAllImageUrls(cardData);
+  if (urls.size === 0) {
+    return new Map();
+  }
+
+  console.log(`[ImageCacher] Found ${urls.size} external image(s) in character "${cardData.data?.name || characterId}"`);
+
+  // Load existing metadata to skip already-cached images
+  const meta = await assetManager.readMetadata(characterId);
+  const cachedUrls = new Set(meta.images.map(i => i.originalUrl));
+
+  // We collect new metadata entries in-memory, then write metadata.json
+  // once at the end to avoid race conditions between parallel downloads.
+  const newEntries = [];
+
+  // Download in batches with concurrency limit
+  const urlArray = [...urls];
+  const imageMap = new Map();
+
+  for (let i = 0; i < urlArray.length; i += concurrency) {
+    const batch = urlArray.slice(i, i + concurrency);
+    const results = await Promise.allSettled(
+      batch.map(async (url) => {
+        // Skip if already cached
+        if (cachedUrls.has(url)) {
+          const existing = meta.images.find(img => img.originalUrl === url);
+          if (existing) {
+            const localPath = `/api/assets/characters/${characterId}/${existing.filename}`;
+            imageMap.set(url, localPath);
+          }
+          return;
+        }
+
+        const result = await downloadImage(url);
+        if (!result) {
+          console.warn(`[ImageCacher] Could not cache image: ${url}`);
+          return;
+        }
+
+        const { buffer, mimeType } = result;
+
+        // Convert to WebP for space savings (JPEG, PNG, GIF → WebP)
+        let finalBuffer = buffer;
+        let finalMimeType = mimeType;
+        if (['image/jpeg', 'image/jpg', 'image/png', 'image/gif'].includes(mimeType)) {
+          try {
+            finalBuffer = await sharp(buffer).webp({ animated: true }).toBuffer();
+            finalMimeType = 'image/webp';
+          } catch (err) {
+            console.warn(`[ImageCacher] WebP conversion failed for ${url}: ${err.message}`);
+          }
+        }
+
+        const hash = sha256(finalBuffer);
+        const ext = mimeTypeToExt(finalMimeType);
+        const filename = `${hash}.${ext}`;
+        const localPath = `/api/assets/characters/${characterId}/${filename}`;
+
+        // Write file directly — metadata is collected and written in bulk at the end
+        await assetManager.writeFileOnly(characterId, filename, finalBuffer);
+
+        newEntries.push({ originalUrl: url, hash, filename, mimeType: finalMimeType });
+        imageMap.set(url, localPath);
+      })
+    );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        console.error('[ImageCacher] Unexpected error in download batch:', result.reason);
+      }
+    }
+  }
+
+  // Write complete metadata once — merges existing cached entries with new ones
+  if (newEntries.length > 0) {
+    const allImages = [...meta.images, ...newEntries];
+    await assetManager.writeMetadata(characterId, { images: allImages });
+  }
+
+  console.log(`[ImageCacher] Cached ${imageMap.size}/${urls.size} image(s) for character "${cardData.data?.name || characterId}"`);
+  return imageMap;
+}
+
+/**
+ * Rewrite all image URLs in the card data text fields using the provided map.
+ *
+ * @param {object}              cardData   — normalized V2 card data (mutated in place)
+ * @param {Map<string, string>} imageMap   — original URL → local path
+ * @returns {object}  — the same cardData object (mutated), for chaining
+ */
+export function rewriteImageUrls(cardData, imageMap) {
+  if (!imageMap || imageMap.size === 0) return cardData;
+  if (!cardData?.data) return cardData;
+
+  const data = cardData.data;
+
+  // Build a single-pass replacement function
+  function replaceUrls(text) {
+    if (!text || typeof text !== 'string') return text;
+
+    // Replace each original URL in the text with its local path
+    for (const [originalUrl, localPath] of imageMap) {
+      // Escape URL for regex special characters
+      const escaped = originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      text = text.replace(new RegExp(escaped, 'g'), localPath);
+    }
+    return text;
+  }
+
+  // Apply to all text fields
+  const fields = [
+    'description',
+    'personality',
+    'scenario',
+    'first_mes',
+    'mes_example',
+    'creator_notes',
+    'system_prompt',
+    'post_history_instructions',
+  ];
+
+  for (const field of fields) {
+    if (data[field] !== undefined) {
+      data[field] = replaceUrls(data[field]);
+    }
+  }
+
+  // Alternate greetings (array of strings)
+  if (Array.isArray(data.alternate_greetings)) {
+    data.alternate_greetings = data.alternate_greetings.map(g => replaceUrls(g));
+  }
+
+  return cardData;
+}
+
+/**
+ * Collect all image URLs from a card's text fields (utility, used externally).
+ *
+ * @param {object} cardData
+ * @returns {Set<string>}
+ */
+export function extractCardImageUrls(cardData) {
+  return collectAllImageUrls(cardData);
+}

--- a/server/src/services/image-cacher.js
+++ b/server/src/services/image-cacher.js
@@ -11,7 +11,7 @@
 import crypto from 'crypto';
 import sharp from 'sharp';
 import { AssetManager } from './asset-manager.js';
-import { MARKDOWN_IMAGE_RE, HTML_IMAGE_RE } from '../../../shared/regex-patterns.js';
+import { MARKDOWN_IMAGE_RE, HTML_IMAGE_RE, IMAGE_EXTENSIONS } from '../../../shared/regex-patterns.js';
 import { IMAGE_MIME_TYPES_MAP, mimeTypeToExt } from '../../../shared/mime-types.js'
 
 // ── Configuration ─────────────────────────────────────────────────────
@@ -94,13 +94,87 @@ function collectAllImageUrls(cardData) {
 }
 
 /**
+ * Collect all image URLs from a lorebook's entry content fields.
+ *
+ * @param {object} lorebookData  — lorebook with .entries[].content fields
+ * @returns {Set<string>}
+ */
+function collectLorebookImageUrls(lorebookData) {
+  if (!lorebookData?.entries || !Array.isArray(lorebookData.entries)) {
+    return new Set();
+  }
+
+  const all = new Set();
+
+  // Scan entry content and comment fields
+  for (const entry of lorebookData.entries) {
+    if (entry.content) {
+      for (const url of extractImageUrls(entry.content)) {
+        all.add(url);
+      }
+    }
+    if (entry.comment) {
+      for (const url of extractImageUrls(entry.comment)) {
+        all.add(url);
+      }
+    }
+  }
+
+  // Also scan lorebook description
+  if (lorebookData.description) {
+    for (const url of extractImageUrls(lorebookData.description)) {
+      all.add(url);
+    }
+  }
+
+  return all;
+}
+
+/**
+ * Validate that a URL is a plausible image URL before attempting to download.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isValidImageUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+
+  try {
+    const parsed = new URL(url);
+
+    // Only http / https are supported
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      console.warn(`[ImageCacher] Skipping non-HTTP URL: ${url}`);
+      return false;
+    }
+
+    // Reject URLs with no hostname
+    if (!parsed.hostname) {
+      console.warn(`[ImageCacher] Skipping URL with no hostname: ${url}`);
+      return false;
+    }
+
+    return true;
+  } catch {
+    console.warn(`[ImageCacher] Skipping malformed URL: ${url}`);
+    return false;
+  }
+}
+
+/**
  * Download a single image from a URL.
  *
  * @param {string} url
  * @returns {Promise<{ buffer: Buffer, mimeType: string } | null>}
- *   Returns null if the download fails or the content is not a valid image.
+ *   Returns null if the URL is invalid, the download fails, or the content
+ *   is not a valid image.
  */
 async function downloadImage(url) {
+  // Validate URL before making any network request
+  if (!isValidImageUrl(url)) {
+    return null;
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
 
@@ -158,44 +232,33 @@ async function downloadImage(url) {
   }
 }
 
-// ── Public API ────────────────────────────────────────────────────────
+// ── Internal: generic caching pipeline ────────────────────────────────
 
 /**
- * Download all external images referenced in a character card, store them
- * locally via AssetManager, and return a mapping of original URL → local path.
+ * Internal: download, convert, and store images for any entity.
  *
- * Only downloads images that are not already cached (by checking metadata).
- * Does NOT modify cardData — call rewriteImageUrls() separately.
- *
- * @param {string}   characterId
- * @param {object}   cardData   — normalized V2 card data
- * @param {string}   dataRoot   — resolved data root path
+ * @param {string}   entityId
+ * @param {Set<string>} urls      — image URLs to cache
+ * @param {string}   dataRoot
+ * @param {string}   entityType   — 'characters' or 'lorebooks'
+ * @param {string}   [label]      — human-readable label for log messages
  * @param {object}   [options]
- * @param {number}   [options.concurrency]  — max parallel downloads (default 3)
+ * @param {number}   [options.concurrency]
  * @returns {Promise<Map<string, string>>}
- *   Map where key = original URL, value = local path (e.g. "/api/assets/characters/{id}/{hash}.jpg")
  */
-export async function cacheExternalImages(characterId, cardData, dataRoot, options = {}) {
-  const assetManager = new AssetManager(dataRoot);
+async function cacheImageSet(entityId, urls, dataRoot, entityType, label, options = {}) {
+  const assetManager = new AssetManager(dataRoot, entityType);
   const concurrency = options.concurrency ?? MAX_CONCURRENT_DOWNLOADS;
 
-  // Collect all unique image URLs from the card
-  const urls = collectAllImageUrls(cardData);
   if (urls.size === 0) {
     return new Map();
   }
 
-  console.log(`[ImageCacher] Found ${urls.size} external image(s) in character "${cardData.data?.name || characterId}"`);
+  console.log(`[ImageCacher] Found ${urls.size} external image(s) in ${entityType.slice(0, -1)} "${label || entityId}"`);
 
-  // Load existing metadata to skip already-cached images
-  const meta = await assetManager.readMetadata(characterId);
+  const meta = await assetManager.readMetadata(entityId);
   const cachedUrls = new Set(meta.images.map(i => i.originalUrl));
-
-  // We collect new metadata entries in-memory, then write metadata.json
-  // once at the end to avoid race conditions between parallel downloads.
   const newEntries = [];
-
-  // Download in batches with concurrency limit
   const urlArray = [...urls];
   const imageMap = new Map();
 
@@ -203,12 +266,10 @@ export async function cacheExternalImages(characterId, cardData, dataRoot, optio
     const batch = urlArray.slice(i, i + concurrency);
     const results = await Promise.allSettled(
       batch.map(async (url) => {
-        // Skip if already cached
         if (cachedUrls.has(url)) {
           const existing = meta.images.find(img => img.originalUrl === url);
           if (existing) {
-            const localPath = `/api/assets/characters/${characterId}/${existing.filename}`;
-            imageMap.set(url, localPath);
+            imageMap.set(url, `/api/assets/${entityType}/${entityId}/${existing.filename}`);
           }
           return;
         }
@@ -221,7 +282,6 @@ export async function cacheExternalImages(characterId, cardData, dataRoot, optio
 
         const { buffer, mimeType } = result;
 
-        // Convert to WebP for space savings (JPEG, PNG, GIF → WebP)
         let finalBuffer = buffer;
         let finalMimeType = mimeType;
         if (['image/jpeg', 'image/jpg', 'image/png', 'image/gif'].includes(mimeType)) {
@@ -236,11 +296,9 @@ export async function cacheExternalImages(characterId, cardData, dataRoot, optio
         const hash = sha256(finalBuffer);
         const ext = mimeTypeToExt(finalMimeType);
         const filename = `${hash}.${ext}`;
-        const localPath = `/api/assets/characters/${characterId}/${filename}`;
+        const localPath = `/api/assets/${entityType}/${entityId}/${filename}`;
 
-        // Write file directly — metadata is collected and written in bulk at the end
-        await assetManager.writeFileOnly(characterId, filename, finalBuffer);
-
+        await assetManager.writeFileOnly(entityId, filename, finalBuffer);
         newEntries.push({ originalUrl: url, hash, filename, mimeType: finalMimeType });
         imageMap.set(url, localPath);
       })
@@ -253,14 +311,77 @@ export async function cacheExternalImages(characterId, cardData, dataRoot, optio
     }
   }
 
-  // Write complete metadata once — merges existing cached entries with new ones
   if (newEntries.length > 0) {
     const allImages = [...meta.images, ...newEntries];
-    await assetManager.writeMetadata(characterId, { images: allImages });
+    await assetManager.writeMetadata(entityId, { images: allImages });
   }
 
-  console.log(`[ImageCacher] Cached ${imageMap.size}/${urls.size} image(s) for character "${cardData.data?.name || characterId}"`);
+  console.log(`[ImageCacher] Cached ${imageMap.size}/${urls.size} image(s) for ${entityType.slice(0, -1)} "${label || entityId}"`);
   return imageMap;
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * Download all external images referenced in a character card, store them
+ * locally via AssetManager, and return a mapping of original URL → local path.
+ *
+ * Only downloads images that are not already cached (by checking metadata).
+ * Does NOT modify cardData — call rewriteCharacterImageUrls() separately.
+ *
+ * @param {string}   characterId
+ * @param {object}   cardData   — normalized V2 card data
+ * @param {string}   dataRoot   — resolved data root path
+ * @param {object}   [options]
+ * @param {number}   [options.concurrency]  — max parallel downloads (default 3)
+ * @returns {Promise<Map<string, string>>}
+ *   Map where key = original URL, value = local path (e.g. "/api/assets/characters/{id}/{hash}.jpg")
+ */
+export async function cacheCharacterImages(characterId, cardData, dataRoot, options = {}) {
+  const urls = collectAllImageUrls(cardData);
+  const label = cardData.data?.name || characterId;
+  return cacheImageSet(characterId, urls, dataRoot, 'characters', label, options);
+}
+
+/**
+ * Download all external images referenced in a lorebook's entry content,
+ * store them locally, and return a mapping of original URL → local path.
+ *
+ * @param {string}   lorebookId
+ * @param {object}   lorebookData  — lorebook with .entries[].content fields
+ * @param {string}   dataRoot
+ * @param {object}   [options]
+ * @param {number}   [options.concurrency]
+ * @returns {Promise<Map<string, string>>}
+ *   Map where key = original URL, value = local path (e.g. "/api/assets/lorebooks/{id}/{hash}.webp")
+ */
+export async function cacheLorebookImages(storage, lorebookId, lorebookData, dataRoot, options = {}) {
+    try {
+      const urls = collectLorebookImageUrls(lorebookData);
+      const label = lorebookData.name || lorebookId;
+      const imageMap = await cacheImageSet(lorebookId, urls, dataRoot, 'lorebooks', label, options);
+      if (imageMap.size > 0) {
+        rewriteLorebookImageUrls(lorebookData, imageMap);
+        const saved = await storage.saveLorebook(lorebookId, lorebookData);
+        console.log(`[Lorebooks] Rewrote ${imageMap.size} image URL(s) in lorebook ${lorebookId}`);
+        return imageMap;
+      }
+    } catch (error) {
+      console.error(`[Lorebooks] Failed to cache images for lorebook ${lorebookId}:`, error);
+    }
+    return null;
+}
+
+function replaceUrls(text, imageMap) {
+  if (!text || typeof text !== 'string') return text;
+
+  // Replace each original URL in the text with its local path
+  for (const [originalUrl, localPath] of imageMap) {
+    // Escape URL for regex special characters
+    const escaped = originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    text = text.replace(new RegExp(escaped, 'g'), localPath);
+  }
+  return text;
 }
 
 /**
@@ -270,24 +391,11 @@ export async function cacheExternalImages(characterId, cardData, dataRoot, optio
  * @param {Map<string, string>} imageMap   — original URL → local path
  * @returns {object}  — the same cardData object (mutated), for chaining
  */
-export function rewriteImageUrls(cardData, imageMap) {
+export function rewriteCharacterImageUrls(cardData, imageMap) {
   if (!imageMap || imageMap.size === 0) return cardData;
   if (!cardData?.data) return cardData;
 
   const data = cardData.data;
-
-  // Build a single-pass replacement function
-  function replaceUrls(text) {
-    if (!text || typeof text !== 'string') return text;
-
-    // Replace each original URL in the text with its local path
-    for (const [originalUrl, localPath] of imageMap) {
-      // Escape URL for regex special characters
-      const escaped = originalUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      text = text.replace(new RegExp(escaped, 'g'), localPath);
-    }
-    return text;
-  }
 
   // Apply to all text fields
   const fields = [
@@ -303,13 +411,13 @@ export function rewriteImageUrls(cardData, imageMap) {
 
   for (const field of fields) {
     if (data[field] !== undefined) {
-      data[field] = replaceUrls(data[field]);
+      data[field] = replaceUrls(data[field], imageMap);
     }
   }
 
   // Alternate greetings (array of strings)
   if (Array.isArray(data.alternate_greetings)) {
-    data.alternate_greetings = data.alternate_greetings.map(g => replaceUrls(g));
+    data.alternate_greetings = data.alternate_greetings.map(g => replaceUrls(g, imageMap));
   }
 
   return cardData;
@@ -323,4 +431,43 @@ export function rewriteImageUrls(cardData, imageMap) {
  */
 export function extractCardImageUrls(cardData) {
   return collectAllImageUrls(cardData);
+}
+
+/**
+ * Collect all image URLs from a lorebook's entry content (utility, used externally).
+ *
+ * @param {object} lorebookData
+ * @returns {Set<string>}
+ */
+export function extractLorebookImageUrls(lorebookData) {
+  return collectLorebookImageUrls(lorebookData);
+}
+
+/**
+ * Rewrite all image URLs in a lorebook's entry content using the provided map.
+ *
+ * @param {object}              lorebookData  — lorebook with .entries[].content (mutated in place)
+ * @param {Map<string, string>} imageMap      — original URL → local path
+ * @returns {object}  — the same lorebookData object (mutated), for chaining
+ */
+export function rewriteLorebookImageUrls(lorebookData, imageMap) {
+  if (!imageMap || imageMap.size === 0) return lorebookData;
+  if (!lorebookData?.entries || !Array.isArray(lorebookData.entries)) return lorebookData;
+
+ // Rewrite in each entry's content and comment
+  for (const entry of lorebookData.entries) {
+    if (entry.content) {
+      entry.content = replaceUrls(entry.content, imageMap);
+    }
+    if (entry.comment) {
+      entry.comment = replaceUrls(entry.comment, imageMap);
+    }
+  }
+
+  // Also rewrite in lorebook description
+  if (lorebookData.description) {
+    lorebookData.description = replaceUrls(lorebookData.description, imageMap);
+  }
+
+  return lorebookData;
 }

--- a/shared/mime-types.js
+++ b/shared/mime-types.js
@@ -1,0 +1,21 @@
+export const IMAGE_MIME_TYPES_MAP = {
+  'image/avif': 'avif',
+  'image/gif': 'gif',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+export const mimeTypeFromExt = (ext) => {
+    if (!ext || ext.lenght == 0) return null;
+    const finalExt = ext[0] == '.' ? ext.slice(1): ext;
+    for (const [key, value] of Object.entries(IMAGE_MIME_TYPES_MAP)) {
+        if (value == finalExt) {
+            return key;
+        }
+    }
+    return null;
+}
+
+export const mimeTypeToExt = (mime) => IMAGE_MIME_TYPES_MAP[mime] || 'bin';

--- a/vue_client/src/components/CharactersTable.vue
+++ b/vue_client/src/components/CharactersTable.vue
@@ -38,6 +38,15 @@
           <i class="fas fa-circle-info"></i> Details
         </button>
         <button
+          class="btn btn-small btn-warning"
+          :disabled="isRefreshing(row.id)"
+          @click="$emit('refresh-images', row.id)"
+          title="Re-download external images and cache locally"
+        >
+          <i :class="isRefreshing(row.id) ? 'fas fa-spinner fa-spin' : 'fas fa-sync-alt'"></i>
+          Refresh
+        </button>
+        <button
           class="btn btn-small btn-secondary"
           @click="$emit('delete', row)"
         >
@@ -62,10 +71,18 @@ const props = defineProps({
   stories: {
     type: Array,
     default: () => []
+  },
+  refreshingIds: {
+    type: Set,
+    default: () => new Set()
   }
 })
 
-defineEmits(['continue', 'new-story', 'edit', 'delete'])
+function isRefreshing(id) {
+  return props.refreshingIds.has(id)
+}
+
+defineEmits(['continue', 'new-story', 'edit', 'delete', 'refresh-images'])
 
 // Use centralized memoized story counts for O(1) lookup
 const { getStoryCount: getCachedStoryCount, storyCountsByCharacter } = useDataCache()

--- a/vue_client/src/components/ImportCharacterModal.vue
+++ b/vue_client/src/components/ImportCharacterModal.vue
@@ -14,11 +14,11 @@
         />
         <button
           class="btn btn-primary full-width"
-          :disabled="!selectedFile || importing"
+          :disabled="!selectedFile || !!importing"
           @click="importFromPhoto"
         >
-          <i class="fas fa-upload"></i>
-          {{ importing ? 'Importing...' : 'Import from Photos' }}
+          <i :class="importing === 'photo' ? 'fas fa-spinner fa-spin' : 'fas fa-upload'"></i>
+          {{ importing === 'photo' ? 'Importing...' : 'Import from Photos' }}
         </button>
       </section>
 
@@ -38,11 +38,11 @@
         />
         <button
           class="btn btn-primary full-width"
-          :disabled="!selectedStorageFile || importing"
+          :disabled="!selectedStorageFile || !!importing"
           @click="importFromStorage"
         >
-          <i class="fas fa-upload"></i>
-          {{ importing ? 'Importing...' : 'Import from Storage' }}
+          <i :class="importing === 'storage' ? 'fas fa-spinner fa-spin' : 'fas fa-upload'"></i>
+          {{ importing === 'storage' ? 'Importing...' : 'Import from Storage' }}
         </button>
       </section>
 
@@ -63,11 +63,11 @@
         />
         <button
           class="btn btn-primary full-width"
-          :disabled="!characterUrl.trim() || importing"
+          :disabled="!characterUrl.trim() || !!importing"
           @click="importFromURL"
         >
-          <i class="fas fa-download"></i>
-          {{ importing ? 'Importing...' : 'Import from URL' }}
+          <i :class="importing === 'url' ? 'fas fa-spinner fa-spin' : 'fas fa-download'"></i>
+          {{ importing === 'url' ? 'Importing...' : 'Import from URL' }}
         </button>
         <small class="hint">Supported: chub.ai, direct image URLs (PNG, JPEG, WebP)</small>
       </section>
@@ -89,7 +89,7 @@ const fileInput = ref(null)
 const selectedStorageFile = ref(null)
 const storageFileInput = ref(null)
 const characterUrl = ref('')
-const importing = ref(false)
+const importing = ref(null) // null | 'photo' | 'storage' | 'url'
 
 function handleFileSelect(event) {
   const file = event.target.files[0]
@@ -109,7 +109,7 @@ async function importFromPhoto() {
   if (!selectedFile.value || importing.value) return
 
   try {
-    importing.value = true
+    importing.value = 'photo'
     const result = await charactersAPI.importPNG(selectedFile.value)
 
     toast.success(`Successfully imported "${result.name}"!`)
@@ -127,7 +127,7 @@ async function importFromURL() {
   if (!characterUrl.value.trim() || importing.value) return
 
   try {
-    importing.value = true
+    importing.value = 'url'
     const result = await charactersAPI.importFromURL(characterUrl.value.trim())
 
     toast.success(`Successfully imported "${result.name}"!`)
@@ -145,7 +145,7 @@ async function importFromStorage() {
   if (!selectedStorageFile.value || importing.value) return
 
   try {
-    importing.value = true
+    importing.value = 'storage'
 
     // Detect if it's an image file (PNG/JPEG) and route accordingly
     const file = selectedStorageFile.value

--- a/vue_client/src/services/api.js
+++ b/vue_client/src/services/api.js
@@ -507,6 +507,12 @@ export const charactersAPI = {
       body: JSON.stringify(data),
     })
   },
+
+  refreshImages(characterId) {
+    return request(`/characters/${characterId}/refresh-images`, {
+      method: 'POST',
+    })
+  },
 }
 
 // Lorebooks API

--- a/vue_client/src/views/LandingPage.vue
+++ b/vue_client/src/views/LandingPage.vue
@@ -80,10 +80,12 @@
           v-else
           :characters="characters"
           :stories="stories"
+          :refreshing-ids="refreshingCharacterIds"
           @continue="showCharacterStories"
           @new-story="createStoryWithCharacter"
           @edit="editCharacter"
           @delete="deleteCharacter"
+          @refresh-images="refreshCharacterImages"
         />
       </template>
 
@@ -270,6 +272,7 @@ const showPresetEditorModal = ref(false)
 const showProviderSelectionModal = ref(false)
 const editingPreset = ref(null)
 const selectedProvider = ref(null)
+const refreshingCharacterIds = ref(new Set())
 
 const characterStoriesForModal = computed(() => {
   if (!selectedCharacter.value) return []
@@ -430,6 +433,31 @@ async function deleteCharacter(character) {
   } catch (error) {
     console.error('Error deleting character:', error)
     toast.error('Failed to delete character: ' + error.message)
+  }
+}
+
+async function refreshCharacterImages(characterId) {
+  const character = characters.value.find(c => c.id === characterId)
+  const name = character?.name || 'Character'
+
+  // Mark as refreshing for spinner
+  refreshingCharacterIds.value = new Set([...refreshingCharacterIds.value, characterId])
+
+  try {
+    const result = await charactersAPI.refreshImages(characterId)
+    if (result.imagesCached > 0) {
+      toast.success(`Cached ${result.imagesCached} new image(s) for ${name}`)
+    } else {
+      toast.success(`All images already cached for ${name}`)
+    }
+  } catch (error) {
+    console.error('Error refreshing images:', error)
+    toast.error('Failed to refresh images: ' + error.message)
+  } finally {
+    // Remove from refreshing set
+    const next = new Set(refreshingCharacterIds.value)
+    next.delete(characterId)
+    refreshingCharacterIds.value = next
   }
 }
 


### PR DESCRIPTION
Caches external images (Markdown and HTML img tags) from character card text fields locally during import, with content-hashed filenames and a manual refresh button for re-caching on existing characters.

New files
server/src/services/asset-manager.js Manages per-character asset directories under {dataRoot}/public-assets/gallery/characters/{characterId}/. Each directory contains {hash}.{ext} files and a metadata.json mapping original URLs to cached filenames.

server/src/services/image-cacher.js Scans all character card text fields (description, personality, first_mes, mes_example, alternate_greetings, etc.) for external image URLs in both Markdown alt and HTML  formats. Downloads images with concurrency (max 3), validates MIME types, computes SHA-256 content hashes for filenames, and rewrites URLs in card data to local paths.

MAX_IMAGE_SIZE: 10 MB, DOWNLOAD_TIMEOUT: 15s per image.
Failures are logged but non-fatal — import continues with
original URLs preserved.

Metadata is written once after all downloads complete to avoid
race conditions between parallel batch downloads.

server/src/routes/assets.js GET /api/assets/characters/:characterId/:filename Serves cached images with proper Content-Type and immutable cache headers (max-age=31536000).

server/src/services/tests/image-cacher.test.js 19 tests covering URL extraction, URL rewriting, and the caching pipeline with mocked fetch and filesystem.

Modified files
server/server.js Registers /api/assets route.

server/src/routes/characters.js Integrates image caching into all character import/create/update endpoints: PNG import, JSON import, URL import, CHUB import, manual create, create-with-image, update, update-with-image. Cleans up asset directory on character delete. Adds POST /api/characters/:characterId/refresh-images for manual re-caching of external images on existing characters.

vue_client/src/services/api.js Adds charactersAPI.refreshImages() method.

vue_client/src/components/CharactersTable.vue Adds "Refresh" button in each row (spinner icon while loading). Accepts refreshingIds Set prop for per-row loading state.

vue_client/src/components/ImportCharacterModal.vue Import buttons show spinner icon on the clicked button only. Uses string state (null | 'photo' | 'storage' | 'url') instead of boolean so each button tracks its own loading state.

vue_client/src/views/LandingPage.vue Handles @refresh-images event with per-character spinner tracking. Passes refreshingCharacterIds set to CharactersTable.

.gitignore Adds plans/ directory.